### PR TITLE
[#119] Changes for logging in SimM (ouroboros-network).

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@
 # - nix build -f default.nix nix-tools.tests.iohk-monitoring.tests
 # - nix build -f default.nix nix-tools.exes.iohk-monitoring # All `iohk-monitoring` executables
 # - nix build -f default.nix nix-tools.cexes.iohk-monitoring.example-simple
-# 
+#
 # Generated targets include anything from stack.yaml (via
 # nix-tools:stack-to-nix and the nix/regenerate.sh script)
 # or cabal.project (via nix-tools:plan-to-nix), including all
@@ -21,9 +21,9 @@
 # Please run `nix/regenerate.sh` after modifying stack.yaml
 # or relevant part of cabal configuration files.
 # When switching to recent stackage or hackage package version,
-# you might also need to update the iohk-nix common lib. You 
+# you might also need to update the iohk-nix common lib. You
 # can do so by running the `nix/update-iohk-nix.sh` script.
-# 
+#
 # More information about iohk-nix and nix-tools is available at:
 # https://github.com/input-output-hk/iohk-nix/blob/master/docs/nix-toolification.org#for-a-stackage-project
 #
@@ -43,8 +43,8 @@ in
 { ... }@args:
 # We will instantiate the default-nix template with the
 # nix/pkgs.nix file...
-commonLib.nix-tools.default-nix ./nix/pkgs.nix args 
+commonLib.nix-tools.default-nix ./nix/pkgs.nix args
 # ... and add additional non-haskell packages we want to build on CI:
 // {
-  
+
 }

--- a/src/Cardano/BM/Data/LogItem.lhs
+++ b/src/Cardano/BM/Data/LogItem.lhs
@@ -20,11 +20,10 @@ module Cardano.BM.Data.LogItem
   )
   where
 
-import           Control.Concurrent (ThreadId, myThreadId)
+import           Control.Concurrent (myThreadId)
 import           Data.Aeson (FromJSON, ToJSON, object, toJSON, (.=))
-import           Data.Text (Text)
+import           Data.Text (Text, pack)
 import           Data.Time.Clock (UTCTime, getCurrentTime)
-
 import           GHC.Generics (Generic)
 
 import           Cardano.BM.Data.Aggregated (Aggregated (..), Measurable (..))
@@ -72,11 +71,14 @@ data LogObject = LogObject LOMeta LOContent
 
 \end{code}
 
-Meta data for a |LogObject|:
+Meta data for a |LogObject|.
+Text was selected over ThreadId in order to be able to use the logging system
+under SimM of ouroboros-network because ThreadId from Control.Concurrent lacks a Read
+instance.
 \begin{code}
 data LOMeta = LOMeta {
                 tstamp :: {-# UNPACK #-} !UTCTime
-              , tid    :: {-# UNPACK #-} !ThreadId
+              , tid    :: {-# UNPACK #-} !Text
               }
               deriving (Show)
 
@@ -87,7 +89,7 @@ instance ToJSON LOMeta where
 mkLOMeta :: IO LOMeta
 mkLOMeta =
     LOMeta <$> getCurrentTime
-           <*> myThreadId
+           <*> (pack . show <$> myThreadId)
 
 \end{code}
 

--- a/src/Cardano/BM/Output/Log.lhs
+++ b/src/Cardano/BM/Output/Log.lhs
@@ -229,7 +229,7 @@ passN backend katip namedLogItem = do
                     if (msg == "") && (isNothing payload)
                     then return ()
                     else do
-                        let threadIdText = KC.mkThreadIdText (tid lometa)
+                        let threadIdText = KC.ThreadIdText $ tid lometa
                         let ns = lnName namedLogItem
                         let itemTime = tstamp lometa
                         let itemKatip = K.Item {
@@ -247,7 +247,6 @@ passN backend katip namedLogItem = do
                                 }
                         void $ atomically $ KC.tryWriteTBQueue shChan (KC.NewItem itemKatip)
                 else return ()
-
 \end{code}
 
 \subsubsection{Scribes}

--- a/src/Cardano/BM/Trace.lhs
+++ b/src/Cardano/BM/Trace.lhs
@@ -22,6 +22,7 @@ module Cardano.BM.Trace
     , typeofTrace
     , evalFilters
     -- * log functions
+    , traceConditionally
     , traceNamedObject
     , traceNamedItem
     , logAlert,     logAlertS,     logAlertP,     logAlertUnsafeP

--- a/test/Cardano/BM/Test/Monitoring.lhs
+++ b/test/Cardano/BM/Test/Monitoring.lhs
@@ -9,7 +9,6 @@ module Cardano.BM.Test.Monitoring (
     tests
   ) where
 
--- import           Control.Monad (forM_)
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
 


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
Changed type of `ThreadId` since in SimM in ouroboros-network it is an `Int` and there is not an `Read ` instance for `ThreadId`. Changes necessary for https://github.com/input-output-hk/ouroboros-network/pull/298.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [x] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
