### PR TITLE
Fix path to static content.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Editor.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Editor.lhs
@@ -56,7 +56,7 @@ startup config = do
         thd <- Async.async $
              startGUI defaultConfig { jsPort       = Just port
                                     , jsAddr       = Just "127.0.0.1"
-                                    , jsStatic     = Just "static"
+                                    , jsStatic     = Just "iohk-monitoring/static"
                                     , jsCustomHTML = Just "configuration-editor.html"
                                     } $ prepare config
         Async.link thd


### PR DESCRIPTION
description
-----------

Because of structure reorganizing GUI didn't work:

```
A web handler threw an exception. Details:
static/configuration-editor.html: getFileStatus: does not exist (No such file or directory)
``` 

Now it's fixed.

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
