### PR TITLE
Update pkgs.nix

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -31,9 +31,9 @@ let
         # does not require any messing with cabal files.
         packages.katip.components.library.doExactConfig = true;
 
-        packages.iohk-monitoring.components.tests.tests.setupTestFlags = [
-          "--show-details=streaming"
-        ];
+#        packages.iohk-monitoring.components.tests.tests.setupTestFlags = [
+#          "--show-details=streaming"
+#        ];
       }
     ];
   };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -30,10 +30,6 @@ let
         # This is similar to jailbreakCabal, however it
         # does not require any messing with cabal files.
         packages.katip.components.library.doExactConfig = true;
-
-#        packages.iohk-monitoring.components.tests.tests.setupTestFlags = [
-#          "--show-details=streaming"
-#        ];
       }
     ];
   };


### PR DESCRIPTION
Disable `--show-details=streaming` in CI. This breaks the tests in windows with
```
  RUNNING TESTS for iohk-monitoring-0.1.6.0-test-tests-x86_64-pc-mingw32 via wine64
  ================================================================================
  Copying extra test libraries ...
  Copying library dependencies...
  ghc-pkg: : getDirectoryContents:openDirStream: does not exist (No such file or directory)
  Running 1 test suites...
  Test suite tests: RUNNING...
  Setup: <file descriptor: 3>: hGetContents: invalid argument (invalid byte sequence)
  <file descriptor: 3>: hGetContents: invalid argument (invalid byte sequence)
  Setup: <file descriptor: 3>: hGetContents: invalid argument (invalid byte sequence)
```