### PR TITLE
bug: bracketObserveIO should append name to named context

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Observer/STM.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Observer/STM.lhs
@@ -25,7 +25,7 @@ import           Cardano.BM.Data.LogItem (LOContent, LOMeta)
 import           Cardano.BM.Data.SubTrace
 import           Cardano.BM.Data.Severity (Severity)
 import           Cardano.BM.Observer.Monadic (observeClose, observeOpen)
-import           Cardano.BM.Trace (Trace)
+import           Cardano.BM.Trace (Trace, appendName)
 
 \end{code}
 %endif
@@ -42,8 +42,9 @@ and run the passed |STM| action on it.
 \begin{code}
 bracketObserveIO :: Config.Configuration -> Trace IO a -> Severity -> Text -> STM.STM t -> IO t
 bracketObserveIO config trace severity name action = do
+    trace' <- appendName name trace
     subTrace <- fromMaybe Neutral <$> Config.findSubTrace config name
-    bracketObserveIO' subTrace severity trace action
+    bracketObserveIO' subTrace severity trace' action
   where
     bracketObserveIO' :: SubTrace -> Severity -> Trace IO a -> STM.STM t -> IO t
     bracketObserveIO' NoTrace _ _ act =
@@ -74,8 +75,9 @@ Otherwise, this function behaves the same as |bracketObserveIO|.
 \begin{code}
 bracketObserveLogIO :: Config.Configuration -> Trace IO a -> Severity -> Text -> STM.STM (t,[(LOMeta, LOContent a)]) -> IO t
 bracketObserveLogIO config trace severity name action = do
+    trace' <- appendName name trace
     subTrace <- fromMaybe Neutral <$> Config.findSubTrace config name
-    bracketObserveLogIO' subTrace severity trace action
+    bracketObserveLogIO' subTrace severity trace' action
   where
     bracketObserveLogIO' :: SubTrace -> Severity -> Trace IO a -> STM.STM (t,[(LOMeta, LOContent a)]) -> IO t
     bracketObserveLogIO' NoTrace _ _ act = do

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -417,7 +417,7 @@ unitHierarchy' subtraces f = do
     -- subsubtrace of type 3
     setSubTrace cfg "test.inner.innermost" (Just t3)
 #ifdef ENABLE_OBSERVABLES
-    _ <- STMObserver.bracketObserveIO cfg trace2 Debug "test.inner.innermost" setVar_
+    _ <- STMObserver.bracketObserveIO cfg trace2 Debug "innermost" setVar_
 #endif
     logInfo trace2 "Message from level 3."
     -- acquire the traced objects


### PR DESCRIPTION

description
-----------

- [ ] `bracketObserveIO` should add the local name to the named context.


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
