### PR TITLE
Less I/O

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -20,6 +20,7 @@ module Cardano.BM.Data.LogItem
   where
 
 import           Control.Concurrent (myThreadId)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Aeson (FromJSON, ToJSON, object, toJSON, (.=))
 import           Data.Text (Text, pack)
 import           Data.Time.Clock (UTCTime, getCurrentTime)
@@ -77,10 +78,10 @@ instance ToJSON LOMeta where
                , "privacy"  .= show _priv
                ]
 
-mkLOMeta :: Severity -> PrivacyAnnotation -> IO LOMeta
+mkLOMeta :: MonadIO m => Severity -> PrivacyAnnotation -> m LOMeta
 mkLOMeta sev priv =
-    LOMeta <$> getCurrentTime
-           <*> (pack . show <$> myThreadId)
+    LOMeta <$> (liftIO getCurrentTime)
+           <*> (pack . show <$> (liftIO myThreadId))
            <*> pure sev
            <*> pure priv
 

--- a/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
@@ -151,7 +151,7 @@ name of the passed in |Trace|.
 \begin{code}
 bracketObserveM :: (MonadCatch m, MonadIO m) => Config.Configuration -> Trace m a -> Severity -> Text -> m t -> m t
 bracketObserveM config trace severity name action = do
-    trace' <- liftIO $ appendName name trace
+    trace' <- appendName name trace
     subTrace <- liftIO $ fromMaybe Neutral <$> Config.findSubTrace config name
     bracketObserveM' subTrace severity trace' action
   where
@@ -184,7 +184,8 @@ name of the passed in |Trace|. This observer bracket does not interfere on excep
 bracketObserveX :: (MonadIO m) => Config.Configuration -> Trace m a -> Severity -> Text -> m t -> m t
 bracketObserveX config trace severity name action = do
     subTrace <- liftIO $ fromMaybe Neutral <$> Config.findSubTrace config name
-    bracketObserveX' subTrace severity trace action
+    trace' <- appendName name trace
+    bracketObserveX' subTrace severity trace' action
   where
     bracketObserveX' :: (MonadIO m) => SubTrace -> Severity -> Trace m a -> m t -> m t
     bracketObserveX' NoTrace _ _ act = act

--- a/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
@@ -11,6 +11,7 @@ module Cardano.BM.Observer.Monadic
     (
       bracketObserveIO
     , bracketObserveM
+    , bracketObserveX
       -- * observing functions
     , observeOpen
     , observeClose
@@ -176,10 +177,38 @@ bracketObserveM config trace severity name action = do
 
 \end{code}
 
+\subsubsection{Monadic.bracketObserver}
+Observes a |MonadIO m => m| action and adds a name to the logger
+name of the passed in |Trace|. This observer bracket does not interfere on exceptions.
+\begin{code}
+bracketObserveX :: (MonadIO m) => Config.Configuration -> Trace m a -> Severity -> Text -> m t -> m t
+bracketObserveX config trace severity name action = do
+    subTrace <- liftIO $ fromMaybe Neutral <$> Config.findSubTrace config name
+    bracketObserveX' subTrace severity trace action
+  where
+    bracketObserveX' :: (MonadIO m) => SubTrace -> Severity -> Trace m a -> m t -> m t
+    bracketObserveX' NoTrace _ _ act = act
+    bracketObserveX' subtrace sev logTrace act = do
+        countersid <- observeOpen0 subtrace sev logTrace
+
+        -- run action
+        t <- act
+
+        observeClose0 subtrace sev logTrace countersid []
+
+        pure t
+
+\end{code}
+
 \subsubsection{observerOpen}\label{observeOpen}
 \begin{code}
 observeOpen :: (MonadCatch m, MonadIO m) => SubTrace -> Severity -> Trace m a -> m (Either SomeException CounterState)
 observeOpen subtrace severity logTrace = (do
+    state <- observeOpen0 subtrace severity logTrace
+    return (Right state)) `catch` (return . Left)
+
+observeOpen0 :: (MonadIO m) => SubTrace -> Severity -> Trace m a -> m CounterState
+observeOpen0 subtrace severity logTrace = do
     identifier <- liftIO newUnique
 
     -- take measurement
@@ -191,7 +220,7 @@ observeOpen subtrace severity logTrace = (do
         -- send opening message to Trace
         meta <- mkLOMeta severity Confidential
         traceNamedObject logTrace (meta, ObserveOpen state)
-    return (Right state)) `catch` (return . Left)
+    return state
 
 \end{code}
 
@@ -202,6 +231,13 @@ observeClose
     -> CounterState -> [(LOMeta, LOContent a)]
     -> m (Either SomeException ())
 observeClose subtrace sev logTrace initState logObjects = (do
+    observeClose0 subtrace sev logTrace initState logObjects
+    return (Right ())) `catch` (return . Left)
+
+observeClose0 :: (MonadIO m) => SubTrace -> Severity -> Trace m a
+    -> CounterState -> [(LOMeta, LOContent a)]
+    -> m ()
+observeClose0 subtrace sev logTrace initState logObjects = do
     let identifier = csIdentifier initState
         initialCounters = csCounters initState
 
@@ -219,6 +255,6 @@ observeClose subtrace sev logTrace initState logObjects = (do
             (mle, ObserveDiff (CounterState identifier (diffCounters initialCounters counters)))
     -- trace the messages gathered from inside the action
     forM_ logObjects $ traceNamedObject logTrace
-    return (Right ())) `catch` (return . Left)
+    return ()
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
@@ -177,7 +177,7 @@ instance ToObject a => IsBackend EKGView a where
         ekghdl <- getLabel "iohk-monitoring version" ehdl
         Label.set ekghdl $ pack (showVersion version)
         ekgtrace <- ekgTrace ekgview config
-        queue <- atomically $ TBQ.newTBQueue 512
+        queue <- atomically $ TBQ.newTBQueue 25120
         dispatcher <- spawnDispatcher queue sbtrace ekgtrace
         -- link the given Async to the current thread, such that if the Async
         -- raises an exception, that exception will be re-thrown in the current


### PR DESCRIPTION

description
-----------

- [x] removing hard dependencies on `IO`, replaced with `MonadIO m => m`,
      and also added `bracketObserveX` which does not depend on `MonadCatch m`
      this was necessary to make benchmarking in cardano-ledger work.


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
