### PR TITLE
repair findSubTrace to only check single name

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -328,16 +328,8 @@ A new context may contain a different type of |Trace|.
 The function |appendName| will look up the |SubTrace| for the context's name.
 \begin{code}
 findSubTrace :: Configuration -> Text -> IO (Maybe SubTrace)
-findSubTrace configuration name = do
-    cg <- readMVar $ getCG configuration
-    let mapsubtrace = cgMapSubtrace cg
-    let find_s lname = case HM.lookup lname mapsubtrace of
-            Nothing ->
-                case dropToDot lname of
-                    Nothing     -> Nothing
-                    Just lname' -> find_s lname'
-            Just st -> Just st
-    return $ find_s name
+findSubTrace configuration name =
+    HM.lookup name <$> cgMapSubtrace <$> (readMVar $ getCG configuration)
 
 setSubTrace :: Configuration -> Text -> Maybe SubTrace -> IO ()
 setSubTrace configuration name trafo =


### PR DESCRIPTION

description
-----------

- [x] recent change introduced: `findSubTrace` may search in parent name contexts; this lead to incorrect behaviour


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
