### PR TITLE
[#242] Change Prometheus' default port

### DIFF
--- a/iohk-monitoring/examples/complex/Main.lhs
+++ b/iohk-monitoring/examples/complex/Main.lhs
@@ -187,7 +187,7 @@ prepare_configuration = do
     CM.setBackends c "#aggregation.complex.observeIO" (Just [EKGViewBK])
     CM.setEKGport c 12789
 #ifdef ENABLE_PROMETHEUS
-    CM.setPrometheusPort c 9090
+    CM.setPrometheusPort c 12799
 #endif
 #endif
 #ifdef ENABLE_GUI

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -475,7 +475,7 @@ setupFromRepresentation r = do
                        Nothing -> 0
                        Just p  -> p
     r_hasPrometheus repr = case (R.hasPrometheus repr) of
-                       Nothing -> 9090 -- default port for Prometheus
+                       Nothing -> 12799 -- default port for Prometheus
                        Just p  -> p
     r_hasGUI repr = case (R.hasGUI repr) of
                        Nothing -> 0
@@ -513,7 +513,7 @@ empty = do
                            , cgDefAggregatedKind = StatsAK
                            , cgMonitors          = HM.empty
                            , cgPortEKG           = 0
-                           , cgPortPrometheus    = 9090
+                           , cgPortPrometheus    = 12799
                            , cgPortGUI           = 0
                            }
     return $ Configuration cgref

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -190,7 +190,7 @@ unitConfigurationStaticRepresentation =
             , defaultBackends = [ KatipBK ]
             , hasGUI = Just 12789
             , hasEKG = Just 18321
-            , hasPrometheus = Just 9090
+            , hasPrometheus = Just 12799
             , options =
                 HM.fromList [ ("test1", (HM.singleton "value" "object1"))
                             , ("test2", (HM.singleton "value" "object2")) ]
@@ -207,7 +207,7 @@ unitConfigurationStaticRepresentation =
             , "setupBackends:"
             , "- EKGViewBK"
             , "- KatipBK"
-            , "hasPrometheus: 9090"
+            , "hasPrometheus: 12799"
             , "hasGUI: 12789"
             , "defaultScribes:"
             , "- - StdoutSK"
@@ -415,7 +415,7 @@ unitConfigurationParsed = do
                                               )
                                             ]
         , cgPortEKG           = 12789
-        , cgPortPrometheus    = 9090 -- the default value
+        , cgPortPrometheus    = 12799 -- the default value
         , cgPortGUI           = 0
         }
 

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -26,7 +26,7 @@ defaultBackends:
 hasEKG: 12789
 
 # if wanted, the Prometheus interface is using this port:
-# hasPrometheus: 9090
+# hasPrometheus: 12799
 
 # here we set up outputs of logging in 'katip':
 setupScribes:


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
Change default Prometheus default port so as not to be in the following list:
https://github.com/prometheus/prometheus/wiki/Default-port-allocations

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
