### PR TITLE
Added systemd in build inputs.

### DIFF
--- a/scripts/nix/stack-shell.nix
+++ b/scripts/nix/stack-shell.nix
@@ -7,6 +7,6 @@ let
 
 in haskell.lib.buildStackProject {
   name = "cardano-ledger-env";
-  buildInputs = [ zlib openssl git ];
+  buildInputs = [ zlib openssl git systemd ];
   ghc = haskell.packages.${compiler}.ghc;
 }


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
`libsystemd` is required by [libsystemd-journal](https://hackage.haskell.org/package/libsystemd-journal) package.

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
