### PR TITLE
[#289] Renamed EKG values & forwarded LogValues properly.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
@@ -118,13 +118,13 @@ ekgTrace ekg _c = do
                 let logname' = logname <> "." <> iname
                 in
                 case value of
-                    (Microseconds x) -> setGauge (logname' <> "_us") (fromIntegral x) ekg_i
-                    (Nanoseconds  x) -> setGauge (logname' <> "_ns") (fromIntegral x) ekg_i
-                    (Seconds      x) -> setGauge (logname' <> "_s")  (fromIntegral x) ekg_i
-                    (Bytes        x) -> setGauge (logname' <> "_B")  (fromIntegral x) ekg_i
-                    (PureI        x) -> setGauge logname' (fromIntegral x) ekg_i
-                    (PureD        _) -> setLabel logname' (pack $ show value) ekg_i
-                    (Severity     _) -> setLabel logname' (pack $ show value) ekg_i
+                    (Microseconds x) -> setGauge ("us:"   <> logname') (fromIntegral x) ekg_i
+                    (Nanoseconds  x) -> setGauge ("ns:"   <> logname') (fromIntegral x) ekg_i
+                    (Seconds      x) -> setGauge ("s:"    <> logname')  (fromIntegral x) ekg_i
+                    (Bytes        x) -> setGauge ("B:"    <> logname')  (fromIntegral x) ekg_i
+                    (PureI        x) -> setGauge ("int:"  <> logname') (fromIntegral x) ekg_i
+                    (PureD        _) -> setLabel ("real:" <> logname') (pack $ show value) ekg_i
+                    (Severity     _) -> setLabel ("sev:"  <> logname') (pack $ show value) ekg_i
 
             update _ _ = return Nothing
 
@@ -179,7 +179,7 @@ instance IsEffectuator EKGView a where
                 traceAgg ags
             (LogObject _ _ (LogMessage _)) -> enqueue item
             (LogObject _ _ (LogValue _ _)) -> enqueue item
-            _                            -> return ()
+            _                              -> return ()
 
     handleOverflow _ = TIO.hPutStrLn stderr "Notice: EKGViews's queue full, dropping log items!"
 
@@ -265,4 +265,3 @@ spawnDispatcher config evqueue sbtrace ekgtrace = do
             Nothing -> return ()  -- stop here
 
 \end{code}
-

--- a/iohk-monitoring/src/Cardano/BM/Output/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Output/Switchboard.lhs
@@ -175,7 +175,11 @@ instance ToObject a => IsBackend Switchboard a where
                                             Warning -- Debug
 
                 let sendMessage nli befilter = do
-                        selectedBackends <- getBackends cfg (loName nli)
+                        let name = case nli of
+                                LogObject loname _ (LogValue valueName _) ->
+                                    loname <> "." <> valueName
+                                LogObject loname _ _ -> loname
+                        selectedBackends <- getBackends cfg name
                         let selBEs = befilter selectedBackends
                         forM_ backends $ \(bek, be) ->
                             when (bek `elem` selBEs) (bEffectuate be nli)


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
EKG seems to have a bug when displaying labels and gauge with the same prefix. So we added a prefix into gauges. 
`LogValue`s weren't directed to the proper backends since the name of their value was not added in the full logname.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [x] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
