### PR TITLE
when flags are set, disable imports/exports

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -4,6 +4,8 @@
 
 %if style == newcode
 \begin{code}
+{-# LANGUAGE CPP #-}
+
 module Cardano.BM.Configuration
     (
       CM.Configuration
@@ -16,8 +18,12 @@ module Cardano.BM.Configuration
     , CM.getOption
     , CM.findSubTrace
     , CM.setSubTrace
+#ifdef ENABLE_EKG
     , CM.getEKGport
+#endif
+#ifdef ENABLE_PROMETHEUS
     , CM.getPrometheusPort
+#endif
     , CM.getGUIport
     , CM.getMonitors
     , getOptionOrDefault

--- a/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Output/EKGView.lhs
@@ -40,7 +40,7 @@ import           System.Remote.Monitoring (Server, forkServer,
 import           Paths_iohk_monitoring (version)
 
 import           Cardano.BM.Configuration (Configuration, getEKGport,
-                     getPrometheusPort, testSubTrace)
+                     testSubTrace)
 import           Cardano.BM.Data.Aggregated
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.LogItem
@@ -50,6 +50,7 @@ import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.Trace
 import           Cardano.BM.Data.Tracer (Tracer (..), ToObject (..))
 #ifdef ENABLE_PROMETHEUS
+import           Cardano.BM.Configuration (getPrometheusPort)
 import           Cardano.BM.Output.Prometheus (spawnPrometheus)
 #endif
 import qualified Cardano.BM.Trace as Trace

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -19,9 +19,11 @@ import           Data.ByteString (intercalate)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import           Data.Yaml
-import           System.FilePath ((</>))
-import           System.IO.Temp (withSystemTempFile)
+#ifdef ENABLE_EKG
 import           System.Directory (getTemporaryDirectory)
+import           System.FilePath ((</>))
+#endif
+import           System.IO.Temp (withSystemTempFile)
 
 import           Cardano.BM.Data.Configuration
 import           Cardano.BM.Configuration.Model (Configuration (..),


### PR DESCRIPTION

description
-----------

- [x] when setting flags like 'disable-ekg' or 'disable-prometheus', exports and imports should be "#ifdef"ed

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
