### PR TITLE
cabal.project: Restrict network version

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,16 @@
 
-packages: ./iohk-monitoring
-          ./contra-tracer
+packages:
+  iohk-monitoring
+  contra-tracer
 
 package iohk-monitoring
   tests: True
 
 package contra-tracer
-  tests: False
+   -- Currently does not have tests, but set it True in case any are added.
+  tests: True
   documentation: True
   haddock-hyperlink-source: True
+
+constraints:
+  network == 3.0.*


### PR DESCRIPTION
Many dependencies fail to compile with network >= 3.1.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
