### PR TITLE
Monitor-actions tests

### DIFF
--- a/iohk-monitoring/test/Cardano/BM/Test/Monitoring.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Monitoring.lhs
@@ -4,16 +4,28 @@
 %if style == newcode
 \begin{code}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.BM.Test.Monitoring (
     tests
   ) where
 
+import           Control.Monad
+import qualified Control.Concurrent.Async as Async
+import           Control.Concurrent (threadDelay)
 import qualified Data.HashMap.Strict as HM
+import           Data.Either (isRight)
 import           Data.Text (Text)
 
+import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.Aggregated
+import           Cardano.BM.Data.BackendKind
+import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MonitoringEval
+import           Cardano.BM.Data.Severity
+import           Cardano.BM.Output.Monitoring
+import           Cardano.BM.Setup
+import           Cardano.BM.Trace
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -25,7 +37,8 @@ import           Test.Tasty.HUnit
 \begin{code}
 tests :: TestTree
 tests = testGroup "Monitoring tests" [
-            unitTests
+              unitTests
+            , actionsTests
         ]
 
 unitTests :: TestTree
@@ -158,6 +171,15 @@ unitTests = testGroup "Unit tests" [
                                                         ]
             ]
 
+actionsTests :: TestTree
+actionsTests = testGroup "Actions tests" [
+                     testCase
+                         "test SetGlobalMinimalSeverity" $
+                         testSetGlobalMinimalSeverity
+                   , testCase
+                         "test AlterSeverity" $
+                         testAlterSeverity
+               ]
 \end{code}
 
 \subsubsection{Unit tests}
@@ -171,5 +193,82 @@ parseEvalExpression t res env =
     case parseMaybe t of
         Nothing -> error "failed to parse"
         Just e  -> evaluate env e @?= res
+
+\end{code}
+
+\subsubsection{Actions tests}
+
+\begin{code}
+monitoringThr :: Trace IO Text -> IO (Async.Async ())
+monitoringThr trace = do
+    trace' <- appendName "monitoring" trace
+    proc <- Async.async $ sendTo trace'
+    return proc
+  where
+    sendTo tr = do
+        (,) <$> (mkLOMeta Warning Public)
+            <*> pure (LogValue "monitMe" (PureI 100))
+        >>= traceNamedObject tr
+
+testSetGlobalMinimalSeverity :: Assertion
+testSetGlobalMinimalSeverity = do
+    let initialGlobalSeverity = Debug
+        targetGlobalSeverity  = Info
+
+    c <- CM.empty
+    CM.setMinSeverity c initialGlobalSeverity
+    CM.setDefaultBackends c [MonitoringBK]
+    CM.setSetupBackends c [MonitoringBK]
+
+    CM.setBackends c "complex.monitoring.monitMe" (Just [MonitoringBK])
+
+    CM.setMonitors c $ HM.fromList
+        [ ( "complex.monitoring"
+          , ( Nothing
+            , Compare "monitMe" (GE, (OpMeasurable 10))
+            , [SetGlobalMinimalSeverity targetGlobalSeverity]
+            )
+          )
+        ]
+
+    (tr' :: Trace IO Text, _) <- setupTrace_ c "complex"
+
+    procMonitoring <- monitoringThr tr'
+    _ <- Async.waitCatch procMonitoring
+
+    threadDelay 1000000  -- 1 second
+    currentGlobalSeverity <- CM.minSeverity c
+    assertBool "Global minimal severity didn't change!" $
+        currentGlobalSeverity == targetGlobalSeverity
+
+testAlterSeverity :: Assertion
+testAlterSeverity = do
+    let initialSeverity = Debug
+        targetSeverity  = Info
+
+    c <- CM.empty
+    CM.setSeverity c "complex.monitoring.monitMe" (Just initialSeverity)
+    CM.setDefaultBackends c [MonitoringBK]
+    CM.setSetupBackends c [MonitoringBK]
+
+    CM.setBackends c "complex.monitoring.monitMe" (Just [MonitoringBK])
+
+    CM.setMonitors c $ HM.fromList
+        [ ( "complex.monitoring"
+          , ( Nothing
+            , Compare "monitMe" (GE, (OpMeasurable 10))
+            , [AlterSeverity "complex.monitoring.monitMe" targetSeverity]
+            )
+          )
+        ]
+
+    (tr' :: Trace IO Text, _) <- setupTrace_ c "complex"
+
+    procMonitoring <- monitoringThr tr'
+    _ <- Async.waitCatch procMonitoring
+
+    threadDelay 1000000  -- 1 second
+    Just currentSeverity <- CM.inspectSeverity c "complex.monitoring.monitMe"
+    assertBool "Severity didn't change!" $ targetSeverity == currentSeverity
 
 \end{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Monitoring.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Monitoring.lhs
@@ -3,18 +3,13 @@
 
 %if style == newcode
 \begin{code}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Cardano.BM.Test.Monitoring (
     tests
   ) where
 
-import           Control.Monad
 import qualified Control.Concurrent.Async as Async
 import           Control.Concurrent (threadDelay)
 import qualified Data.HashMap.Strict as HM
-import           Data.Either (isRight)
 import           Data.Text (Text)
 
 import qualified Cardano.BM.Configuration.Model as CM
@@ -23,7 +18,6 @@ import           Cardano.BM.Data.BackendKind
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MonitoringEval
 import           Cardano.BM.Data.Severity
-import           Cardano.BM.Output.Monitoring
 import           Cardano.BM.Setup
 import           Cardano.BM.Trace
 
@@ -231,12 +225,12 @@ testSetGlobalMinimalSeverity = do
           )
         ]
 
-    (tr' :: Trace IO Text, _) <- setupTrace_ c "complex"
+    tr' <- setupTrace (Right c) "complex"
 
     procMonitoring <- monitoringThr tr'
     _ <- Async.waitCatch procMonitoring
 
-    threadDelay 1000000  -- 1 second
+    threadDelay 10000  -- 10 ms
     currentGlobalSeverity <- CM.minSeverity c
     assertBool "Global minimal severity didn't change!" $
         currentGlobalSeverity == targetGlobalSeverity
@@ -262,12 +256,12 @@ testAlterSeverity = do
           )
         ]
 
-    (tr' :: Trace IO Text, _) <- setupTrace_ c "complex"
+    tr' <- setupTrace (Right c) "complex"
 
     procMonitoring <- monitoringThr tr'
     _ <- Async.waitCatch procMonitoring
 
-    threadDelay 1000000  -- 1 second
+    threadDelay 10000  -- 10 ms
     Just currentSeverity <- CM.inspectSeverity c "complex.monitoring.monitMe"
     assertBool "Severity didn't change!" $ targetSeverity == currentSeverity
 


### PR DESCRIPTION
description
-----------

- [x] Tests for `monitor`-actions.
  - [x] set global minimal severity
  - [x] alter particular severity

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [x] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
