### PR TITLE
Update to lts-13.24 and ghc-8.6.5

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -15,9 +15,9 @@
         contra-tracer = ./contra-tracer.nix;
         iohk-monitoring = ./iohk-monitoring.nix;
         };
-      compiler.version = "8.6.4";
-      compiler.nix-name = "ghc864";
+      compiler.version = "8.6.5";
+      compiler.nix-name = "ghc865";
       };
-  resolver = "lts-13.15";
-  compiler = "ghc-8.6.4";
+  resolver = "lts-13.24";
+  compiler = "ghc-8.6.5";
   }

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "a2a976a26119662756327e278b6ca9cd20e2f6f0",
-  "date": "2019-05-22T01:24:15+00:00",
-  "sha256": "1qcwvzgp86cixzvd9lmfy6fcr4yw62nn8cnxkm2lp8dkik8yhx87",
+  "rev": "138b2ec4f9800284203910cefa437df4ae0fd1e7",
+  "date": "2019-06-11T03:33:57+00:00",
+  "sha256": "0ggdysn042dryl9gfla5p55k6fmlpynypvmnva7p84qjn9hmq3mi",
   "fetchSubmodules": false
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-13.15
-compiler: ghc-8.6.4
+resolver: lts-13.24
+compiler: ghc-8.6.5
 packages:
 - contra-tracer
 - iohk-monitoring


### PR DESCRIPTION
Update to match `cardano-prelude` and others.

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
