### PR TITLE
cabal: Add flags for switching of syslog/systemd and examples

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -42,6 +42,16 @@ flag disable-observables
   default:             False
   manual:              True
 
+flag disable-syslog
+  description:         Turn off syslog and systemd facilities.
+  default:             False
+  manual:              True
+
+flag disable-examples
+  description:         Turn off building of examples.
+  default:             False
+  manual:              True
+
 library
   hs-source-dirs:      src
   exposed-modules:     Paths_iohk_monitoring
@@ -154,7 +164,8 @@ library
   else
      build-depends:    unix
 
-  if os(linux)
+  if os(linux) && !flag(disable-syslog)
+     cpp-options:      -DENABLE_SYSLOG
      build-depends:    hsyslog,
                        libsystemd-journal
 
@@ -267,6 +278,8 @@ executable example-simple
      build-depends:    Win32
   else
      build-depends:    unix
+  if flag(disable-examples)
+    buildable:         False
 
 executable example-complex
   hs-source-dirs:      examples/complex
@@ -308,3 +321,6 @@ executable example-complex
 
   if !flag(disable-observables)
     cpp-options:       -DENABLE_OBSERVABLES
+
+  if flag(disable-examples)
+    buildable:         False

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -7,6 +7,8 @@
       disable-gui = false;
       disable-monitoring = false;
       disable-observables = false;
+      disable-syslog = false;
+      disable-examples = false;
       };
     package = {
       specVersion = "1.10";
@@ -63,7 +65,9 @@
           (hsPkgs.warp)
           ]) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs.threepenny-gui)) ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
-          else [ (hsPkgs.unix) ])) ++ (pkgs.lib).optionals (system.isLinux) [
+          else [
+            (hsPkgs.unix)
+            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-syslog) [
           (hsPkgs.hsyslog)
           (hsPkgs.libsystemd-journal)
           ];


### PR DESCRIPTION
I added some extra cabal flags to further reduce dependencies if they aren't required. This is useful when cross compiling to difficult targets.
