### PR TITLE
Make `Severity` an instance of `Bounded`.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs
@@ -52,7 +52,7 @@ data Severity = Debug
               | Critical
               | Alert
               | Emergency
-                deriving (Show, Eq, Ord, Enum, Generic, ToJSON, Read)
+                deriving (Show, Eq, Ord, Bounded, Enum, Generic, ToJSON, Read)
 
 instance FromJSON Severity where
     parseJSON = withText "severity" $ \case


### PR DESCRIPTION
With this instance and the pre-existing `Enum` instance, it becomes trivial to generate an ordered list of all `Severity` values:

```hs
> [minBound @Severity .. maxBound]
[Debug,Info,Notice,Warning,Error,Critical,Alert,Emergency]
```

One can also use the [`enumerate`](http://hackage.haskell.org/package/extra-1.6.17/docs/Data-List-Extra.html#v:enumerate) function:

```hs
> enumerate @Severity
[Debug,Info,Notice,Warning,Error,Critical,Alert,Emergency]
```