### PR TITLE
Use builds-on-supported-systems to build shell on darwin.

### DIFF
--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "138b2ec4f9800284203910cefa437df4ae0fd1e7",
-  "date": "2019-06-11T03:33:57+00:00",
-  "sha256": "0ggdysn042dryl9gfla5p55k6fmlpynypvmnva7p84qjn9hmq3mi",
+  "rev": "c0a39aa30cbf11d31b2ab34575c3c8ba3b2610e1",
+  "date": "2019-06-18T12:07:36+02:00",
+  "sha256": "17k0nablxr5nqas7fmk4dxbxmpcvzhwbf03wsvf2kflih09nr01p",
   "fetchSubmodules": false
 }

--- a/release.nix
+++ b/release.nix
@@ -13,6 +13,10 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
   # are interested in building on CI via nix-tools.
   packages = [ "iohk-monitoring" ];
 
+  # non nix-tools jobs from default.nix that we want to build for
+  # all supported systems.
+  builds-on-supported-systems = [ "shell" ];
+
   # The set of jobs we consider crutial for each CI run.
   # if a single one of these fails, the build will be marked
   # as failed.
@@ -57,6 +61,7 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
     # Disabled due to: https://github.com/psibi/download/issues/17:
     #jobs.nix-tools.exes.x86_64-pc-mingw32-iohk-monitoring.x86_64-linux
 
-    jobs.shell
+    jobs.shell.x86_64-linux
+    jobs.shell.x86_64-darwin
   ];
 } args)


### PR DESCRIPTION
(based on https://github.com/input-output-hk/iohk-nix/pull/102).