### PR TITLE
Add minimal flags build to CI and fix build error with -fdisable-syslog

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -203,10 +203,8 @@ instance (ToObject a, FromJSON a) => IsBackend Log a where
                                                             rotParams
                                                             (FileDescription $ unpack name)
                                                             False
-#if defined(linux_HOST_OS)
 #if defined(ENABLE_SYSLOG)
             createScribe JournalSK _ _ _ = mkJournalScribe
-#endif
 #endif
             createScribe StdoutSK sctype _ _ = mkStdoutScribe sctype
             createScribe StderrSK sctype _ _ = mkStderrScribe sctype

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -10,10 +10,6 @@
 
 {-@ LIQUID "--max-case-expand=4" @-}
 
-#if defined(linux_HOST_OS)
-#define LINUX
-#endif
-
 module Cardano.BM.Configuration.Model
     ( Configuration (..)
     , ConfigurationInternal (..)
@@ -479,7 +475,7 @@ setupFromRepresentation r = do
     fillRotationParams :: Maybe RotationParameters -> [ScribeDefinition] -> [ScribeDefinition]
     fillRotationParams defaultRotation = map $ \sd ->
         if (scKind sd /= StdoutSK) && (scKind sd /= StderrSK)
-#ifdef LINUX
+#ifdef ENABLE_SYSLOG
             && (scKind sd /= JournalSK)
 #endif
         then

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,7 +1,11 @@
 { pkgs ? import <nixpkgs> {}
+# package set extensions from iohk-nix
 , iohk-extras ? {}
+# package set configuration from iohk-nix
 , iohk-module ? {}
+# Haskell.nix library
 , haskell
+# iohk-nix might call this with more arguments
 , ...
 }:
 let
@@ -21,6 +25,8 @@ let
     inherit stack-pkgs;
     pkg-def-extras = [
       iohk-extras.${compiler}
+      # Add a clone of iohk-monitoring package
+      (hackage: { packages.iohk-monitoring-minimal = ./.stack.nix/iohk-monitoring.nix; })
     ];
     modules = [
       iohk-module
@@ -33,6 +39,20 @@ let
         # lift containers==0.5.* restriction, see
         # https://github.com/bitnomial/prometheus/commit/61bb7ec834279d6274c9d13b0edcfff3cc42c856
         packages.prometheus.components.library.doExactConfig = true;
+
+        # Add a variant of iohk-monitoring to test disabling of flags
+        packages.iohk-monitoring-minimal.flags = {
+          disable-aggregation = true;
+          disable-ekg = true;
+          disable-graylog = true;
+          disable-prometheus = true;
+          disable-gui = true;
+          disable-monitoring = true;
+          disable-observables = true;
+          disable-syslog = true;
+          # Keep examples, to see if they build
+          disable-examples = false;
+        };
       }
     ];
   };

--- a/release.nix
+++ b/release.nix
@@ -11,7 +11,7 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
 
   # packages from our stack.yaml or plan file (via nix/pkgs.nix) we
   # are interested in building on CI via nix-tools.
-  packages = [ "iohk-monitoring" ];
+  packages = [ "iohk-monitoring" "iohk-monitoring-minimal" ];
 
   # The set of jobs we consider crutial for each CI run.
   # if a single one of these fails, the build will be marked
@@ -52,6 +52,10 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
     jobs.nix-tools.tests.iohk-monitoring.tests.x86_64-linux
 
     jobs.nix-tools.exes.iohk-monitoring.x86_64-linux
+
+    # Linux "minimal" cabal flags builds
+    jobs.nix-tools.libs.iohk-monitoring-minimal.x86_64-linux
+    jobs.nix-tools.exes.iohk-monitoring-minimal.x86_64-linux
 
     # Disabled due to: https://github.com/psibi/download/issues/17:
     #jobs.nix-tools.exes.x86_64-pc-mingw32-iohk-monitoring.x86_64-linux


### PR DESCRIPTION
OK, this is getting embarrassing now. The `disable-syslog` flag was still broken.
I have added a build to CI to check this in future.
