### PR TITLE
set severity of #messagecounters to Debug; they're per default 'NoTrace'

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Aggregation.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Aggregation.lhs
@@ -157,7 +157,7 @@ spawnDispatcher conf aggMap aggregationQueue basetrace = do
                                 "#messagecounters.aggregation"
                                 countersMVar
                                 60000   -- 60000 ms = 1 min
-                                Warning -- Debug
+                                Debug
 
     Async.async $ qProc trace countersMVar aggMap
   where

--- a/iohk-monitoring/src/Cardano/BM/Backend/EKGView.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/EKGView.lhs
@@ -245,7 +245,7 @@ spawnDispatcher config evqueue sbtrace ekgtrace = do
                                 "#messagecounters.ekgview"
                                 countersMVar
                                 60000   -- 60000 ms = 1 min
-                                Warning -- Debug
+                                Debug
 
     Async.async $ qProc countersMVar
   where

--- a/iohk-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
@@ -137,7 +137,7 @@ spawnDispatcher mqueue config sbtrace monitor = do
                                 "#messagecounters.monitoring"
                                 countersMVar
                                 60000   -- 60000 ms = 1 min
-                                Warning
+                                Debug
     Async.async (initMap >>= qProc countersMVar)
   where
     {-@ lazy qProc @-}

--- a/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
@@ -189,7 +189,7 @@ instance (FromJSON a, ToObject a) => IsBackend Switchboard a where
                                             "#messagecounters.switchboard"
                                             countersMVar
                                             60000   -- 60000 ms = 1 min
-                                            Warning -- Debug
+                                            Debug
 
                 let sendMessage nli befilter = do
                         let name = case nli of

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -540,7 +540,13 @@ empty = do
                            { cgMinSeverity       = Debug
                            , cgDefRotation       = Nothing
                            , cgMapSeverity       = HM.empty
-                           , cgMapSubtrace       = HM.empty
+                           , cgMapSubtrace       = HM.fromList [
+                                                     ("#messagecounters.ekgview", NoTrace),
+                                                     ("#messagecounters.aggregation", NoTrace),
+                                                     ("#messagecounters.switchboard", NoTrace),
+                                                     ("#messagecounters.monitoring", NoTrace),
+                                                     ("#messagecounters.katip", NoTrace),
+                                                     ("#messagecounters.graylog", NoTrace) ]
                            , cgOptions           = HM.empty
                            , cgMapBackend        = HM.empty
                            , cgDefBackendKs      = []


### PR DESCRIPTION

description
-----------

- [x] severity of #messagecounters is Debug; per default these messages are 'NoTrace'


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
