### PR TITLE
Fixed bugs in creating and opening pipes.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
@@ -405,11 +405,9 @@ setupBackend' TraceAcceptorBK c sb = do
       { bEffectuate = Cardano.BM.Backend.TraceAcceptor.effectuate be
       , bUnrealize = Cardano.BM.Backend.TraceAcceptor.unrealize be
       }
-setupBackend' TraceForwarderBK c sb = do
-    let basetrace = mainTraceConditionally c sb
-
+setupBackend' TraceForwarderBK c _ = do
     be :: Cardano.BM.Backend.TraceForwarder.TraceForwarder PipeType a
-            <- Cardano.BM.Backend.TraceForwarder.realizefrom c basetrace sb
+            <- Cardano.BM.Backend.TraceForwarder.realize c
     return $ Just MkBackend
       { bEffectuate = Cardano.BM.Backend.TraceForwarder.effectuate be
       , bUnrealize = Cardano.BM.Backend.TraceForwarder.unrealize be

--- a/iohk-monitoring/src/Cardano/BM/Backend/TraceAcceptor.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/TraceAcceptor.lhs
@@ -72,7 +72,7 @@ instance (Pipe p, FromJSON a) => IsBackend (TraceAcceptor p) a where
         elref <- newEmptyMVar
         let externalLog = TraceAcceptor elref
             pipePath = "log-pipe"
-        h <- create pipePath sbtrace
+        h <- create pipePath
         dispatcher <- spawnDispatcher h sbtrace
         -- link the given Async to the current thread, such that if the Async
         -- raises an exception, that exception will be re-thrown in the current

--- a/iohk-monitoring/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -13,7 +13,7 @@
 module Cardano.BM.Backend.TraceForwarder
     ( TraceForwarder (..)
     , effectuate
-    , realizefrom
+    , realize
     , unrealize
     ) where
 
@@ -78,13 +78,11 @@ jsonToBS a =
 instance (Pipe p, FromJSON a, ToJSON a) => IsBackend (TraceForwarder p) a where
     typeof _ = TraceForwarderBK
 
-    realize _ = fail "ExternalLog cannot be instantiated by 'realize'"
-
-    realizefrom cfg sbtrace _ = do
+    realize cfg = do
         ltpref <- newEmptyMVar
         let logToPipe = TraceForwarder ltpref
         pipePath <- fromMaybe "log-pipe" <$> getLogOutput cfg
-        h <- open pipePath sbtrace
+        h <- open pipePath
         putMVar ltpref $ TraceForwarderInternal
                             { tfPipeHandler = h
                             }


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
In the initialization of `TraceForwarderBK` if the pipe file is missing `TraceForwarder` will try to log the exception in the `SwitchBoard` which will wait for this backend to setup. (deadlock)

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
