### PR TITLE
[#362] Point to ekg-prometheus-adapter's fork.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,3 +14,8 @@ package contra-tracer
 
 constraints:
   network == 3.0.*
+
+source-repository-package
+  type: git
+  location: https://github.com/365andreas/ekg-prometheus-adapter
+  tag: fe48327538b32de62c9bffd9d1ac517ba85c7750


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
Point to ekg-prometheus-adapter's fork which can handle labels that contain `Double` values.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [ ] add milestone (the same as the linked issue)
