### PR TITLE
Fixed termination functions of backends.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
@@ -220,7 +220,9 @@ instance (FromJSON a, ToObject a) => IsBackend Switchboard a where
 
                                 case loitem of
                                     KillPill -> do
+                                        -- each of the backends will be terminated sequentially
                                         forM_ backends ( \(_, be) -> bUnrealize be )
+                                        -- all backends have terminated
                                         return False
                                     (AggregatedMessage _) -> do
                                         sendMessage nli (filter (/= AggregationBK))


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
Fixed termination functions in Monitoring, EKGView, Graylog, TraceAcceptor.
Previously we were ignoring the termination of the aforementioned backends.
Now we send a termination message to and wait for dispatchers to finish processing of `LogObject`s.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
