### PR TITLE
cabal: Rename disable-syslog to disable-systemd

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -47,8 +47,8 @@ flag disable-observables
   default:             False
   manual:              True
 
-flag disable-syslog
-  description:         Turn off syslog and systemd facilities.
+flag disable-systemd
+  description:         Turn off systemd journal scribe.
   default:             False
   manual:              True
 
@@ -180,8 +180,8 @@ library
   else
      build-depends:    unix
 
-  if os(linux) && !flag(disable-syslog)
-     cpp-options:      -DENABLE_SYSLOG
+  if os(linux) && !flag(disable-systemd)
+     cpp-options:      -DENABLE_SYSTEMD
      build-depends:    hsyslog,
                        libsystemd-journal
 

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -54,7 +54,7 @@ import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory)
 import           System.IO (BufferMode (LineBuffering), Handle, hClose,
                      hSetBuffering, stderr, stdout, openFile, IOMode (WriteMode))
-#ifdef ENABLE_SYSLOG
+#ifdef ENABLE_SYSTEMD
 import           Data.Aeson (encode)
 import qualified Data.ByteString.Lazy as BL (toStrict)
 import qualified Data.Text.Encoding as T (encodeUtf8)
@@ -71,7 +71,7 @@ import           Paths_iohk_monitoring (version)
 import qualified Katip as K
 import qualified Katip.Core as KC
 import           Katip.Scribes.Handle (brackets)
-#ifdef ENABLE_SYSLOG
+#ifdef ENABLE_SYSTEMD
 import           Katip.Format.Time (formatAsIso8601)
 #endif
 
@@ -203,7 +203,7 @@ instance (ToObject a, FromJSON a) => IsBackend Log a where
                                                             rotParams
                                                             (FileDescription $ unpack name)
                                                             False
-#if defined(ENABLE_SYSLOG)
+#if defined(ENABLE_SYSTEMD)
             createScribe JournalSK _ _ _ = mkJournalScribe
 #endif
             createScribe StdoutSK sctype _ _ = mkStdoutScribe sctype
@@ -572,7 +572,7 @@ prefixPath = takeDirectory . filePath
 \end{code}
 
 \begin{code}
-#ifdef ENABLE_SYSLOG
+#ifdef ENABLE_SYSTEMD
 mkJournalScribe :: IO K.Scribe
 mkJournalScribe = return $ journalScribe Nothing (sev2klog Debug) K.V3
 

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -475,7 +475,7 @@ setupFromRepresentation r = do
     fillRotationParams :: Maybe RotationParameters -> [ScribeDefinition] -> [ScribeDefinition]
     fillRotationParams defaultRotation = map $ \sd ->
         if (scKind sd /= StdoutSK) && (scKind sd /= StderrSK)
-#ifdef ENABLE_SYSLOG
+#ifdef ENABLE_SYSTEMD
             && (scKind sd /= JournalSK)
 #endif
         then

--- a/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
@@ -42,7 +42,7 @@ This identifies katip's scribes by type.
 data ScribeKind = FileSK
                 | StdoutSK
                 | StderrSK
-#ifdef ENABLE_SYSLOG
+#ifdef ENABLE_SYSTEMD
                 | JournalSK
 #endif
                 | DevNullSK

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -8,7 +8,7 @@
       disable-gui = false;
       disable-monitoring = false;
       disable-observables = false;
-      disable-syslog = false;
+      disable-systemd = false;
       disable-examples = false;
       queue-flush = false;
       };
@@ -69,7 +69,7 @@
           then [ (hsPkgs.Win32) ]
           else [
             (hsPkgs.unix)
-            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-syslog) [
+            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-systemd) [
           (hsPkgs.hsyslog)
           (hsPkgs.libsystemd-journal)
           ];


### PR DESCRIPTION
Make the name match what's being disabled. There is no syslog scribe, only a systemd journal scribe. The hsyslog package is just used to provide the Facility data type.

Note: edit https://github.com/input-output-hk/iohk-monitoring-framework/wiki/Compiling-with-flags-set after this is merged.