### PR TITLE
[#257] Enable monitoring of external processes.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Counters/Dummy.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Counters/Dummy.lhs
@@ -27,15 +27,16 @@ import           Cardano.BM.Data.SubTrace
 \label{code:Dummy.readCounters}\index{Counters!Dummy!readCounters}
 \begin{code}
 readCounters :: SubTrace -> IO [Counter]
-readCounters NoTrace               = return []
-readCounters Neutral               = return []
-readCounters (TeeTrace _)          = return []
-readCounters (FilterTrace _)       = return []
-readCounters UntimedTrace          = return []
-readCounters DropOpening           = return []
-readCounters (SetSeverity _)       = return []
+readCounters NoTrace                       = return []
+readCounters Neutral                       = return []
+readCounters (TeeTrace _)                  = return []
+readCounters (FilterTrace _)               = return []
+readCounters UntimedTrace                  = return []
+readCounters DropOpening                   = return []
+readCounters (SetSeverity _)               = return []
 #ifdef ENABLE_OBSERVABLES
-readCounters (ObservableTrace tts) = readCounters' tts []
+readCounters (ObservableTraceSelf tts)     = readCounters' tts []
+readCounters (ObservableTrace     _   tts) = readCounters' tts []
 
 readCounters' :: [ObservableInstance] -> [Counter] -> IO [Counter]
 readCounters' [] acc = return acc
@@ -43,6 +44,7 @@ readCounters' (MonotonicClock : r) acc = getMonoClock >>= \xs -> readCounters' r
 readCounters' (GhcRtsStats    : r) acc = readRTSStats >>= \xs -> readCounters' r $ acc ++ xs
 readCounters' (_              : r) acc = readCounters' r acc
 #else
-readCounters (ObservableTrace _)   = return []
+readCounters (ObservableTraceSelf _)   = return []
+readCounters (ObservableTrace     _ _) = return []
 #endif
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
@@ -246,7 +246,6 @@ observeClose0 subtrace sev logTrace initState logObjects = do
     else do
         mle <- mkLOMeta sev Confidential
         -- send closing message to Trace
-        -- liftIO $ putStrLn $ "Counterssssssssssssssssssssssssssssssssssssssssssssssssss: " ++ show counters
         traceNamedObject logTrace $
             (mle, ObserveClose (CounterState counters))
         -- send diff message to Trace
@@ -254,7 +253,6 @@ observeClose0 subtrace sev logTrace initState logObjects = do
             (mle, ObserveDiff (CounterState (diffCounters initialCounters counters)))
     -- trace the messages gathered from inside the action
     forM_ logObjects $ traceNamedObject logTrace
-    -- liftIO $ putStrLn $ "Counterssssssssssssssssssssssssssssssssssssssssssssssssss: "
     return ()
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Observer/Monadic.lhs
@@ -98,7 +98,7 @@ in a configuration file (YAML) means
         CM.setSubTrace
             config
             "submit-tx"
-            (Just $ ObservableTrace observablesSet)
+            (Just $ ObservableTraceSelf observablesSet)
           where
             observablesSet = [MonotonicClock, MemoryStats]
 \end{spec}
@@ -120,9 +120,8 @@ in a configuration file (YAML) means
 \begin{code}
 bracketObserveIO :: Config.Configuration -> Trace IO a -> Severity -> Text -> IO t -> IO t
 bracketObserveIO config trace severity name action = do
-    trace' <- appendName name trace
     subTrace <- fromMaybe Neutral <$> Config.findSubTrace config name
-    bracketObserveIO' subTrace severity trace' action
+    bracketObserveIO' subTrace severity trace action
   where
     bracketObserveIO' :: SubTrace -> Severity -> Trace IO a -> IO t -> IO t
     bracketObserveIO' NoTrace _ _ act = act
@@ -247,6 +246,7 @@ observeClose0 subtrace sev logTrace initState logObjects = do
     else do
         mle <- mkLOMeta sev Confidential
         -- send closing message to Trace
+        -- liftIO $ putStrLn $ "Counterssssssssssssssssssssssssssssssssssssssssssssssssss: " ++ show counters
         traceNamedObject logTrace $
             (mle, ObserveClose (CounterState counters))
         -- send diff message to Trace
@@ -254,6 +254,7 @@ observeClose0 subtrace sev logTrace initState logObjects = do
             (mle, ObserveDiff (CounterState (diffCounters initialCounters counters)))
     -- trace the messages gathered from inside the action
     forM_ logObjects $ traceNamedObject logTrace
+    -- liftIO $ putStrLn $ "Counterssssssssssssssssssssssssssssssssssssssssssssssssss: "
     return ()
 
 \end{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -263,7 +263,7 @@ unitConfigurationParsedRepresentation = do
             , "      contents:"
             , "      - GhcRtsStats"
             , "      - MonotonicClock"
-            , "      subtrace: ObservableTrace"
+            , "      subtrace: ObservableTraceSelf"
             , "    iohk.deadend:"
             , "      subtrace: NoTrace"
             , "  mapSeverity:"
@@ -332,13 +332,13 @@ unitConfigurationParsed = do
                                             , ("iohk.testing.uncritical", Warning)
                                             ]
         , cgMapSubtrace       = HM.fromList [ ("iohk.benchmarking",
-                                                    ObservableTrace [GhcRtsStats, MonotonicClock])
+                                                    ObservableTraceSelf [GhcRtsStats, MonotonicClock])
                                             , ("iohk.deadend", NoTrace)
                                             ]
         , cgOptions           = HM.fromList
             [ ("mapSubtrace",
                 HM.fromList [("iohk.benchmarking",
-                              Object (HM.fromList [("subtrace",String "ObservableTrace")
+                              Object (HM.fromList [("subtrace",String "ObservableTraceSelf")
                                                   ,("contents",Array $ V.fromList
                                                         [String "GhcRtsStats"
                                                         ,String "MonotonicClock"])]))

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -71,7 +71,7 @@ tests = testGroup "Testing Trace" [
         unit_tests
       , testCase "forked traces stress testing" stressTraceInFork
 #ifdef ENABLE_OBSERVABLES
-      , testCase "stress testing: ObservableTrace vs. NoTrace" timingObservableVsUntimed
+      , testCase "stress testing: ObservableTraceSelf vs. NoTrace" timingObservableVsUntimed
 #endif
       , testCaseInfo "demonstrating logging" simpleDemo
       , testCaseInfo "demonstrating nested named context logging" exampleWithNamedContexts
@@ -83,10 +83,10 @@ unit_tests = testGroup "Unit tests" [
     --   , testCase "hierarchy of traces" unitHierarchy
       , testCase "forked traces" unitTraceInFork
       , testCase "hierarchy of traces with NoTrace" $
-            unitHierarchy' [Neutral, NoTrace, (ObservableTrace observablesSet)]
+            unitHierarchy' [Neutral, NoTrace, (ObservableTraceSelf observablesSet)]
                 onlyLevelOneMessage
       , testCase "hierarchy of traces with DropOpening" $
-            unitHierarchy' [Neutral, DropOpening, (ObservableTrace observablesSet)]
+            unitHierarchy' [Neutral, DropOpening, (ObservableTraceSelf observablesSet)]
                 notObserveOpen
       , testCase "hierarchy of traces with UntimedTrace" $
             unitHierarchy' [Neutral, UntimedTrace, UntimedTrace]
@@ -188,7 +188,7 @@ exampleWithNamedContexts = do
         trInner <- appendName "inner-work-1" tr
         let observablesSet = [MonotonicClock]
         setSubTrace cfg "test.complex-work-1.inner-work-1.STM-action" $
-            Just $ ObservableTrace observablesSet
+            Just $ ObservableTraceSelf observablesSet
 #ifdef ENABLE_OBSERVABLES
         _ <- STMObserver.bracketObserveIO cfg trInner Debug "STM-action" setVar_
 #endif
@@ -230,7 +230,7 @@ timingObservableVsUntimed = do
     traceObservable <- setupTrace $ TraceConfiguration cfg1
                                     (MockSB msgs1)
                                     "observables"
-                                    (ObservableTrace observablesSet)
+                                    (ObservableTraceSelf observablesSet)
     cfg2 <- defaultConfigTesting
     msgs2 <- STM.newTVarIO []
     traceUntimed <- setupTrace $ TraceConfiguration cfg2
@@ -251,10 +251,10 @@ timingObservableVsUntimed = do
     ms <- STM.readTVarIO msgs1
 
     assertBool
-        ("Untimed consumed more time than ObservableTrace " ++ (show [t_untimed, t_observable]) ++ show ms)
+        ("Untimed consumed more time than ObservableTraceSelf " ++ (show [t_untimed, t_observable]) ++ show ms)
         (t_observable > t_untimed && not (null ms))
     assertBool
-        ("NoTrace consumed more time than ObservableTrace" ++ (show [t_notrace, t_observable]))
+        ("NoTrace consumed more time than ObservableTraceSelf" ++ (show [t_notrace, t_observable]))
         (t_observable > t_notrace)
     assertBool
         ("NoTrace consumed more time than Untimed" ++ (show [t_notrace, t_untimed]))

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -72,7 +72,7 @@ options:
     iohk.testing.uncritical: Warning
   mapSubtrace:
     iohk.benchmarking:
-      subtrace: ObservableTrace
+      subtrace: ObservableTraceSelf
       contents:
         - GhcRtsStats
         - MonotonicClock


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
A new kind of `SubTrace` was added
```haskell
ObservableTrace ProcessID [ObservableInstance]
```
where one can specify the PID of the desirable process to monitor and the type of the measurements to be taken.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
