### PR TITLE
Fix windows build

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
@@ -26,7 +26,7 @@ module Cardano.BM.Data.SubTrace
 #ifdef POSIX
 import           System.Posix.Types (ProcessID, CPid (..))
 #else
-import           System.Win32.Process (ProcessID)
+import           System.Win32.Process (ProcessId)
 #endif
 import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.:), (.=), object, withObject)
 import           Data.Text (Text, pack, unpack)
@@ -76,6 +76,16 @@ instance ToJSON ProcessID where
 
 instance FromJSON ProcessID where
     parseJSON v = CPid <$> parseJSON v
+#else
+-- Wrap the Win32 DWORD type alias so that it can be logged
+newtype ProcessID = ProcessID ProcessId
+    deriving (Generic, Show, Read, Eq)
+
+instance ToJSON ProcessID where
+    toJSON (ProcessID pid) = String $ pack $ show pid
+
+instance FromJSON ProcessID where
+    parseJSON v = ProcessID <$> parseJSON v
 #endif
 
 instance FromJSON SubTrace where

--- a/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
@@ -72,7 +72,7 @@ data SubTrace = Neutral
 
 #ifdef POSIX
 instance ToJSON ProcessID where
-    toJSON (CPid pid) = String $ pack $ show pid
+    toJSON (CPid pid) = Number $ fromIntegral pid
 
 instance FromJSON ProcessID where
     parseJSON v = CPid <$> parseJSON v
@@ -82,7 +82,7 @@ newtype ProcessID = ProcessID ProcessId
     deriving (Generic, Show, Read, Eq)
 
 instance ToJSON ProcessID where
-    toJSON (ProcessID pid) = String $ pack $ show pid
+    toJSON (ProcessID pid) = Number $ fromIntegral pid
 
 instance FromJSON ProcessID where
     parseJSON v = ProcessID <$> parseJSON v

--- a/release.nix
+++ b/release.nix
@@ -60,5 +60,6 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
     # Disabled due to: https://github.com/psibi/download/issues/17:
     #jobs.nix-tools.exes.x86_64-pc-mingw32-iohk-monitoring.x86_64-linux
 
+    jobs.nix-tools.libs.x86_64-pc-mingw32-iohk-monitoring.x86_64-linux
   ];
 } args)


### PR DESCRIPTION
Issue #257 

The windows build got broken in #387. I have fixed it and added a windows cross build of the library to the CI required job.

Side note: I think the `ToJSON ProcessID` instances should be encoding as aeson `Number` not `String`.
