### PR TITLE
Get backends searches to root

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -154,10 +154,17 @@ or, in case no such configuration exists, return the default backends.
 getBackends :: Configuration -> LoggerName -> IO [BackendKind]
 getBackends configuration name = do
     cg <- readMVar $ getCG configuration
-    let outs = HM.lookup name (cgMapBackend cg)
-    case outs of
-        Nothing -> return (cgDefBackendKs cg)
-        Just os -> return os
+    -- let outs = HM.lookup name (cgMapBackend cg)
+    -- case outs of
+    --     Nothing -> return (cgDefBackendKs cg)
+    --     Just os -> return os
+    let defs = cgDefBackendKs cg
+    let mapbks = cgMapBackend cg
+    let find_s [] = defs
+        find_s lnames = case HM.lookup (T.intercalate "." lnames) mapbks of
+            Nothing -> find_s (init lnames)
+            Just os -> os
+    return $ find_s $ T.split (=='.') name
 
 getDefaultBackends :: Configuration -> IO [BackendKind]
 getDefaultBackends configuration =

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -293,6 +293,10 @@ unitConfigurationParsedRepresentation = do
             , "    - FileSK::testlog"
             , "    iohk.background.process: FileSK::testlog"
             , "  mapBackends:"
+            , "    iohk.user.defined:"
+            , "    - kind: UserDefinedBK"
+            , "      name: MyBackend"
+            , "    - KatipBK"
             , "    iohk.interesting.value:"
             , "    - EKGViewBK"
             , "    - AggregationBK"
@@ -369,12 +373,22 @@ unitConfigurationParsed = do
                                             Array $ V.fromList [String "StdoutSK::stdout"
                                                                ,String "FileSK::testlog"])
                                          ,("iohk.background.process",String "FileSK::testlog")])
-            , ("mapBackends", HM.fromList [("iohk.interesting.value",
+            , ("mapBackends", HM.fromList [("iohk.user.defined",
+                                                Array $ V.fromList [Object (HM.fromList [("kind", String "UserDefinedBK")
+                                                                                        ,("name", String "MyBackend")])
+                                                                    ,String "KatipBK"
+                                                                   ])
+                                          ,("iohk.interesting.value",
                                                 Array $ V.fromList [String "EKGViewBK"
                                                                    ,String "AggregationBK"
                                                                    ])])
             ]
-        , cgMapBackend        = HM.fromList [ ("iohk.interesting.value"
+        , cgMapBackend        = HM.fromList [ ("iohk.user.defined"
+                                              , [ UserDefinedBK "MyBackend"
+                                                , KatipBK
+                                                ]
+                                              )
+                                            , ("iohk.interesting.value"
                                               , [ EKGViewBK
                                                 , AggregationBK
                                                 ]

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -83,6 +83,10 @@ options:
     iohk.interesting.value:
       - EKGViewBK
       - AggregationBK
+    iohk.user.defined:
+      - kind: UserDefinedBK
+        name: MyBackend
+      - KatipBK
   mapScribes:
     iohk.interesting.value:
       - "StdoutSK::stdout"


### PR DESCRIPTION

description
-----------

- [x] parsing of UserDefinedBK and 'getBackends' searching to the root of the context name


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
