### PR TITLE
Added timeouts for CI.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,7 @@ steps:
     agents:
       system: x86_64-linux
     branches: "master"
+    timeout: 30
 
   - label: "make TeX documentation"
     command: "cd docs; nix-shell --run make"
@@ -28,8 +29,10 @@ steps:
     command: 'ci/check-hydra.sh'
     agents:
       system: x86_64-linux
+    timeout: 30
 
   - label: 'stack2nix'
     command: 'ci/check-stack2nix.sh'
     agents:
       system: x86_64-linux
+    timeout: 30


### PR DESCRIPTION
description
-----------

- [x] describe solution here ..
A build job had been running for over a week trying to evaluate release.nix (it's stuck on trying to download something from github that hung). So we are restricting the build limit to 30 mins.

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [x] add estimate points
- [ ] add milestone (the same as the linked issue)
