### PR TITLE
updated automatically assigned reviewers of PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # General reviewers per PR
-*                       @codiepp @365andreas
+*                       @codiepp @denisshevchenko
 
 # Specific reviewers for code pieces
 


### PR DESCRIPTION
description
-----------

- [x] updating `CODEOWNERS`; used for automatically selecting reviewers on PRs
