### PR TITLE
[#277] tracer verbosity in ToObject instances

### DIFF
--- a/docs/references.fmt
+++ b/docs/references.fmt
@@ -167,6 +167,7 @@
 %format Cardano.BM.Data.Tracer = "\hyperref[code:Cardano.BM.Data.Tracer]{Cardano.BM.Data.Tracer}"
 %format ToLogObject = "\hyperref[code:ToLogObject]{ToLogObject}"
 %format toLogObject = "\hyperref[code:toLogObject]{toLogObject}"
+%format TracingVerbosity = "\hyperref[code:TracingVerbosity]{TracingVerbosity}"
 %format toObject = "\hyperref[code:toObject]{toObject}"
 %format Transformable = "\hyperref[code:Transformable]{Transformable}"
 %format trTransformer = "\hyperref[code:trTransformer]{trTransformer}"
@@ -254,3 +255,4 @@
 %format Cardano.BM.Test.Tracer = "\hyperref[code:Cardano.BM.Test.Tracer]{Cardano.BM.Test.Tracer}"
 
 %endif
+

--- a/docs/references.fmt
+++ b/docs/references.fmt
@@ -167,10 +167,20 @@
 %format Cardano.BM.Data.Tracer = "\hyperref[code:Cardano.BM.Data.Tracer]{Cardano.BM.Data.Tracer}"
 %format ToLogObject = "\hyperref[code:ToLogObject]{ToLogObject}"
 %format toLogObject = "\hyperref[code:toLogObject]{toLogObject}"
+%format toLogObject' = "\hyperref[code:toLogObject']{toLogObject'}"
+%format toLogObjectVerbose = "\hyperref[code:toLogObjectVerbose]{toLogObjectVerbose}"
+%format toLogObjectMinimal = "\hyperref[code:toLogObjectMinimal]{toLogObjectMinimal}"
 %format TracingVerbosity = "\hyperref[code:TracingVerbosity]{TracingVerbosity}"
+%format MinimalVerbosity = "\hyperref[code:MinimalVerbosity]{MinimalVerbosity}"
+%format NormalVerbosity = "\hyperref[code:NormalVerbosity]{NormalVerbosity}"
+%format MaximalVerbosity = "\hyperref[code:MaximalVerbosity]{MaximalVerbosity}"
+%format ToObject = "\hyperref[code:ToObject]{ToObject}"
 %format toObject = "\hyperref[code:toObject]{toObject}"
+%format mkObject = "\hyperref[code:mkObject]{mkObject}"
+%format emptyObject = "\hyperref[code:emptyObject]{emptyObject}"
 %format Transformable = "\hyperref[code:Transformable]{Transformable}"
 %format trTransformer = "\hyperref[code:trTransformer]{trTransformer}"
+%format trStructured = "\hyperref[code:trStructured]{trStructured}"
 %format setSeverity = "\hyperref[code:setSeverity]{setSeverity}"
 %format severityDebug = "\hyperref[code:severityDebug]{severityDebug}"
 %format severityInfo = "\hyperref[code:severityInfo]{severityInfo}"
@@ -255,4 +265,3 @@
 %format Cardano.BM.Test.Tracer = "\hyperref[code:Cardano.BM.Test.Tracer]{Cardano.BM.Test.Tracer}"
 
 %endif
-

--- a/iohk-monitoring/src/Cardano/BM/Backend/Graylog.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Graylog.lhs
@@ -46,7 +46,6 @@ import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MessageCounter (MessageCounter, resetCounters,
                      sendAndResetAfter, updateMessageCounters)
 import           Cardano.BM.Data.Severity
-import           Cardano.BM.Data.Tracer (ToObject (..))
 import qualified Cardano.BM.Trace as Trace
 
 \end{code}
@@ -110,7 +109,7 @@ instance IsEffectuator Graylog a where
 
 |Graylog| is an |IsBackend|
 \begin{code}
-instance (ToObject a, FromJSON a) => IsBackend Graylog a where
+instance (ToJSON a, FromJSON a) => IsBackend Graylog a where
     typeof _ = GraylogBK
 
     realize _ = fail "Graylog cannot be instantiated by 'realize'"
@@ -152,7 +151,7 @@ instance (ToObject a, FromJSON a) => IsBackend Graylog a where
 
 \subsubsection{Asynchronously reading log items from the queue and their processing}
 \begin{code}
-spawnDispatcher :: forall a. ToObject a
+spawnDispatcher :: forall a. ToJSON a
                 => Configuration
                 -> TBQ.TBQueue (Maybe (LogObject a))
                 -> Trace.Trace IO a
@@ -197,7 +196,7 @@ spawnDispatcher config evqueue sbtrace = do
                 mConn' <- tryConnect gltrace
                 processGraylog item (gltrace, counters, mConn')
 
-    sendLO :: ToObject a => Net.Socket -> LogObject a -> IO ()
+    sendLO :: Net.Socket -> LogObject a -> IO ()
     sendLO conn obj =
         let msg = BS8.toStrict $ encodeMessage obj
         in sendAll conn msg
@@ -218,7 +217,7 @@ spawnDispatcher config evqueue sbtrace = do
                 return Nothing
         return res
 
-    encodeMessage :: ToObject a => LogObject a -> BS8.ByteString
+    encodeMessage :: ToJSON a => LogObject a -> BS8.ByteString
     encodeMessage lo = encode $ mkGelfItem lo
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
@@ -38,7 +38,7 @@ import           Control.Concurrent.STM (TVar, atomically, modifyTVar, retry)
 import qualified Control.Concurrent.STM.TBQueue as TBQ
 import           Control.Exception.Safe (throwM)
 import           Control.Monad (forM_, when, void)
-import           Data.Aeson (FromJSON)
+import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text.IO as TIO
@@ -55,7 +55,7 @@ import           Cardano.BM.Data.MessageCounter (resetCounters, sendAndResetAfte
                      updateMessageCounters)
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.SubTrace (SubTrace (..))
-import           Cardano.BM.Data.Tracer (Tracer (..), ToObject, traceWith)
+import           Cardano.BM.Data.Tracer (Tracer (..), traceWith)
 import qualified Cardano.BM.Backend.TraceAcceptor
 import qualified Cardano.BM.Backend.Log
 import qualified Cardano.BM.Backend.LogBuffer
@@ -166,7 +166,7 @@ instance IsEffectuator Switchboard a where
 
 |Switchboard| is an |IsBackend|
 \begin{code}
-instance (FromJSON a, ToObject a) => IsBackend Switchboard a where
+instance (FromJSON a, ToJSON a) => IsBackend Switchboard a where
     typeof _ = SwitchboardBK
 
     realize cfg = do
@@ -335,7 +335,7 @@ readLogBuffer switchboard = do
 
 \subsubsection{Realizing the backends according to configuration}\label{code:setupBackends}\index{Switchboard!setupBackends}
 \begin{code}
-setupBackends :: (FromJSON a, ToObject a)
+setupBackends :: (FromJSON a, ToJSON a)
               => [BackendKind]
               -> Configuration
               -> Switchboard a
@@ -348,7 +348,7 @@ setupBackends bes c sb = setupBackendsAcc bes []
             Nothing -> setupBackendsAcc r acc
             Just be -> setupBackendsAcc r ((bk,be) : acc)
 
-setupBackend' :: (FromJSON a, ToObject a) => BackendKind -> Configuration -> Switchboard a -> IO (Maybe (Backend a))
+setupBackend' :: (FromJSON a , ToJSON a) => BackendKind -> Configuration -> Switchboard a -> IO (Maybe (Backend a))
 setupBackend' SwitchboardBK _ _ = fail "cannot instantiate a further Switchboard"
 setupBackend' (UserDefinedBK _) _ _ = fail "cannot instantiate an user-defined backend"
 #ifdef ENABLE_MONITORING

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -34,7 +34,7 @@ import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.=),
 import           Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Base64.Lazy as BS64
-import           Data.Text (Text, drop, isPrefixOf, pack)
+import           Data.Text (Text, pack, stripPrefix)
 import qualified Data.Text.Lazy as LT
 import           Data.Text.Lazy.Encoding (encodeUtf8, decodeUtf8)
 import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -116,12 +116,10 @@ mkLOMeta sev priv =
            <*> pure sev
            <*> pure priv
   where
-    cleantid threadid =
-        let stid = pack $ show threadid
-        in
-        if (isPrefixOf "ThreadId " stid)
-        then Data.Text.drop 9 stid
-        else stid
+    cleantid threadid = do
+        let prefixText = "ThreadId "
+            condStripPrefix s = maybe s id $ stripPrefix prefixText s
+        condStripPrefix $ (pack . show) threadid
 
 \end{code}
 

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -34,7 +34,7 @@ import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.=),
 import           Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Base64.Lazy as BS64
-import           Data.Text (Text, pack)
+import           Data.Text (Text, drop, isPrefixOf, pack)
 import qualified Data.Text.Lazy as LT
 import           Data.Text.Lazy.Encoding (encodeUtf8, decodeUtf8)
 import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -111,10 +111,17 @@ instance FromJSON LOMeta where
 
 mkLOMeta :: MonadIO m => Severity -> PrivacyAnnotation -> m LOMeta
 mkLOMeta sev priv =
-    LOMeta <$> (liftIO getCurrentTime)
-           <*> (pack . show <$> (liftIO myThreadId))
+    LOMeta <$> liftIO getCurrentTime
+           <*> (cleantid <$> liftIO myThreadId)
            <*> pure sev
            <*> pure priv
+  where
+    cleantid threadid =
+        let stid = pack $ show threadid
+        in
+        if (isPrefixOf "ThreadId " stid)
+        then Data.Text.drop 9 stid
+        else stid
 
 \end{code}
 

--- a/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/SubTrace.lhs
@@ -28,7 +28,8 @@ import           System.Posix.Types (ProcessID, CPid (..))
 #else
 import           System.Win32.Process (ProcessId)
 #endif
-import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.:), (.=), object, withObject)
+import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.:),
+                     (.=), object, withObject)
 import           Data.Text (Text, unpack)
 import           GHC.Generics (Generic)
 
@@ -105,15 +106,24 @@ instance FromJSON SubTrace where
                         other                 -> fail $ "unexpected subtrace: " ++ (unpack other)
 
 instance ToJSON SubTrace where
-    toJSON Neutral                  = object [ "subtrace" .= String "Neutral"             ]
-    toJSON UntimedTrace             = object [ "subtrace" .= String "UntimedTrace"        ]
-    toJSON NoTrace                  = object [ "subtrace" .= String "NoTrace"             ]
-    toJSON (TeeTrace name)          = object [ "subtrace" .= String "TeeTrace"            , "contents" .= toJSON name ]
-    toJSON (FilterTrace dus)        = object [ "subtrace" .= String "FilterTrace"         , "contents" .= toJSON dus  ]
-    toJSON DropOpening              = object [ "subtrace" .= String "DropOpening"         ]
-    toJSON (ObservableTraceSelf os) = object [ "subtrace" .= String "ObservableTraceSelf" , "contents" .= toJSON os   ]
-    toJSON (ObservableTrace pid os) = object [ "subtrace" .= String "ObservableTrace"     , "pid"      .= toJSON pid
-                                             , "contents" .= toJSON os                    ]
-    toJSON (SetSeverity sev)        = object [ "subtrace" .= String "SetSeverity"         , "contents" .= toJSON sev  ]
+    toJSON Neutral =
+        object [ "subtrace" .= String "Neutral"             ]
+    toJSON UntimedTrace =
+        object [ "subtrace" .= String "UntimedTrace"        ]
+    toJSON NoTrace =
+        object [ "subtrace" .= String "NoTrace"             ]
+    toJSON (TeeTrace name) =
+        object [ "subtrace" .= String "TeeTrace"            , "contents" .= toJSON name ]
+    toJSON (FilterTrace dus) =
+        object [ "subtrace" .= String "FilterTrace"         , "contents" .= toJSON dus  ]
+    toJSON DropOpening =
+        object [ "subtrace" .= String "DropOpening"         ]
+    toJSON (ObservableTraceSelf os) =
+        object [ "subtrace" .= String "ObservableTraceSelf" , "contents" .= toJSON os   ]
+    toJSON (ObservableTrace pid os) =
+        object [ "subtrace" .= String "ObservableTrace"     , "pid"      .= toJSON pid
+               , "contents" .= toJSON os                    ]
+    toJSON (SetSeverity sev) =
+        object [ "subtrace" .= String "SetSeverity"         , "contents" .= toJSON sev  ]
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Setup.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Setup.lhs
@@ -23,7 +23,7 @@ module Cardano.BM.Setup
 
 import           Control.Exception.Safe (MonadMask, bracket)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Data.Aeson (FromJSON)
+import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Text (Text)
 import           System.IO (FilePath)
 
@@ -41,13 +41,13 @@ or a |FilePath| to a configuration file. After all tracing operations have ended
 |shutdownTrace| must be called.
 \begin{code}
 
-setupTrace :: (MonadIO m, FromJSON a, ToObject a) => Either FilePath Config.Configuration -> Text -> m (Trace m a)
+setupTrace :: (MonadIO m, ToJSON a, FromJSON a, ToObject a) => Either FilePath Config.Configuration -> Text -> m (Trace m a)
 setupTrace (Left cfgFile) name = do
     c <- liftIO $ Config.setup cfgFile
     fst <$> setupTrace_ c name
 setupTrace (Right c) name = fst <$> setupTrace_ c name
 
-setupTrace_ :: (MonadIO m, FromJSON a, ToObject a) => Config.Configuration -> Text -> m (Trace m a, Switchboard.Switchboard a)
+setupTrace_ :: (MonadIO m, ToJSON a, FromJSON a, ToObject a) => Config.Configuration -> Text -> m (Trace m a, Switchboard.Switchboard a)
 setupTrace_ c name = do
     sb <- liftIO $ Switchboard.realize c
 
@@ -59,7 +59,7 @@ setupTrace_ c name = do
 \subsubsection{shutdown}\label{code:shutdown}\index{shutdown}
 Shut down the Switchboard and all the |Trace|s related to it.
 \begin{code}
-shutdown :: (FromJSON a, ToObject a) => Switchboard.Switchboard a -> IO ()
+shutdown :: (ToJSON a, FromJSON a, ToObject a) => Switchboard.Switchboard a -> IO ()
 shutdown = Switchboard.unrealize
 
 \end{code}
@@ -68,7 +68,7 @@ shutdown = Switchboard.unrealize
 Setup a |Trace| from |Configuration| and pass it to the action. At the end,
 shutdown all the components and close the trace.
 \begin{code}
-withTrace :: (MonadIO m, MonadMask m, FromJSON a, ToObject a) =>  Config.Configuration -> Text -> (Trace m a -> m t) -> m t
+withTrace :: (MonadIO m, MonadMask m, ToJSON a, FromJSON a, ToObject a) =>  Config.Configuration -> Text -> (Trace m a -> m t) -> m t
 withTrace cfg name action =
     bracket
         (setupTrace_ cfg name)              -- aquire

--- a/tracer-transformers/example1/Main.hs
+++ b/tracer-transformers/example1/Main.hs
@@ -5,7 +5,6 @@
 
 module Main where
 
-import           Control.Concurrent (ThreadId, myThreadId)
 import           Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar,
                      modifyMVar_, putMVar, readMVar, tryTakeMVar, withMVar)
 import           Control.Monad.IO.Class (MonadIO (..))

--- a/tracer-transformers/example2/Main.hs
+++ b/tracer-transformers/example2/Main.hs
@@ -6,7 +6,6 @@
 
 module Main where
 
-import           Control.Concurrent (ThreadId, myThreadId)
 import           Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar,
                      modifyMVar_, putMVar, readMVar, tryTakeMVar, withMVar)
 import           Control.Monad.IO.Class (MonadIO (..))


### PR DESCRIPTION

description
-----------

- [x] control verbosity of data structures via `TracerVerbosity` and instances of `ToObject`


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [x] link to an epic
- [x] add estimate points
- [x] add milestone (the same as the linked issue)
