### PR TITLE
tracing formatting hint added to ToObject, Transformable

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Tracing.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Tracing.lhs
@@ -13,7 +13,11 @@ module Cardano.BM.Tracing
     , Severity (..)
     , ToLogObject (..)
     , ToObject (..)
+    , Transformable (..)
+    , TracingVerbosity (..)
+    , TracingFormatting (..)
     , appendName
+    , contramap
     , defaultConfigStdout
     , defaultConfigTesting
     , mkLOMeta
@@ -22,14 +26,16 @@ module Cardano.BM.Tracing
     , traceWith
     ) where
 
-import           Control.Tracer (Tracer (..), nullTracer, traceWith)
+import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 import           Cardano.BM.Configuration.Static (defaultConfigStdout,
                      defaultConfigTesting)
 import           Cardano.BM.Data.LogItem (LogObject (..),
                      PrivacyAnnotation (..), mkLOMeta)
 import           Cardano.BM.Data.Severity (Severity (..))
 import           Cardano.BM.Data.Trace (Trace)
-import           Cardano.BM.Data.Tracer (ToLogObject (..), ToObject (..))
+import           Cardano.BM.Data.Tracer (ToLogObject (..), ToObject (..),
+                     TracingFormatting (..), TracingVerbosity (..),
+                     Transformable (..))
 import           Cardano.BM.Setup (setupTrace)
 import           Cardano.BM.Trace (appendName)
 


### PR DESCRIPTION

description
-----------

- [x] added a tracing formatting hint to `ToObject`. Different formatting can be implemented in `Transformable` instances. Default is "StructuredLogging". This will allow us to change the formatting at runtime.


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
