### PR TITLE
define privacy annotation and severity on types

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -219,7 +219,7 @@ class DefineSeverity a where
     default defineSeverity :: a -> Severity
     defineSeverity _ = Debug
 
--- | default instances
+-- default instances
 instance DefinePrivacyAnnotation Int
 instance DefineSeverity Int
 instance DefinePrivacyAnnotation Integer

--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -342,25 +342,25 @@ instance Transformable Text IO Text where
     trTransformer _ _ tr = Tracer $ \arg ->
         traceWith tr =<<
             LogObject <$> pure ""
-                      <*> (mkLOMeta Debug Public)
+                      <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
                       <*> pure (LogMessage arg)
 instance Transformable String IO String where
     trTransformer _ _ tr = Tracer $ \arg ->
         traceWith tr =<<
             LogObject <$> pure ""
-                      <*> (mkLOMeta Debug Public)
+                      <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
                       <*> pure (LogMessage arg)
 instance Transformable Text IO String where
     trTransformer _ _ tr = Tracer $ \arg ->
         traceWith tr =<<
             LogObject <$> pure ""
-                      <*> (mkLOMeta Debug Public)
+                      <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
                       <*> pure (LogMessage $ T.pack arg)
 instance Transformable String IO Text where
     trTransformer _ _ tr = Tracer $ \arg ->
         traceWith tr =<<
             LogObject <$> pure ""
-                      <*> (mkLOMeta Debug Public)
+                      <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
                       <*> pure (LogMessage $ T.unpack arg)
 
 \end{code}
@@ -370,14 +370,15 @@ to their |ToObject| representation and further traces them as a |LogObject| of t
 |LogStructured|. If the |ToObject| representation is empty, then no tracing happens.
 \label{code:trStructured}\index{trStructured}
 \begin{code}
-trStructured :: (ToObject b, MonadIO m) => TracingVerbosity -> Tracer m (LogObject a) -> Tracer m b
+trStructured :: (ToObject b, MonadIO m, DefinePrivacyAnnotation b, DefineSeverity b)
+             => TracingVerbosity -> Tracer m (LogObject a) -> Tracer m b
 trStructured verb tr = Tracer $ \arg ->
         let obj = toObject verb arg
             tracer = if obj == emptyObject then nullTracer else tr
         in
         traceWith tracer =<<
             LogObject <$> pure ""
-                      <*> (mkLOMeta Debug Public)
+                      <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
                       <*> pure (LogStructured $ encode $ obj)
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Tracing.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Tracing.lhs
@@ -14,6 +14,8 @@ module Cardano.BM.Tracing
     , ToLogObject (..)
     , ToObject (..)
     , Transformable (..)
+    , DefinePrivacyAnnotation (..)
+    , DefineSeverity (..)
     , TracingVerbosity (..)
     , TracingFormatting (..)
     , appendName
@@ -33,7 +35,8 @@ import           Cardano.BM.Data.LogItem (LogObject (..),
                      PrivacyAnnotation (..), mkLOMeta)
 import           Cardano.BM.Data.Severity (Severity (..))
 import           Cardano.BM.Data.Trace (Trace)
-import           Cardano.BM.Data.Tracer (ToLogObject (..), ToObject (..),
+import           Cardano.BM.Data.Tracer (DefinePrivacyAnnotation (..),
+                     DefineSeverity (..), ToLogObject (..), ToObject (..),
                      TracingFormatting (..), TracingVerbosity (..),
                      Transformable (..))
 import           Cardano.BM.Setup (setupTrace)

--- a/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
@@ -89,9 +89,9 @@ instance Transformable Text IO Pet where
         traceWith tr $ LogObject "pet" meta $ (LogMessage . pack . show) pet
     trTransformer _ _verb _tr = nullTracer
 
--- | default privacy annotation: Public
+-- default privacy annotation: Public
 instance DefinePrivacyAnnotation Pet
--- | default severity: Debug
+-- default severity: Debug
 instance DefineSeverity Pet
 
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
@@ -18,13 +18,9 @@ import           Data.Text (Text, pack)
 
 import           Cardano.BM.Configuration.Static
 import           Cardano.BM.Data.LogItem
-import           Cardano.BM.Data.Tracer (Tracer (..), ToObject (..),
-                     TracingFormatting (..), TracingVerbosity (..),
-                     Transformable (..), annotateConfidential, emptyObject,
-                     mkObject, nullTracer, severityNotice, toLogObject',
-                     toLogObject, toLogObjectMinimal, toLogObjectVerbose,
-                     traceWith, trStructured)
-import           Cardano.BM.Data.Severity
+import           Cardano.BM.Tracing hiding (setupTrace)
+import           Cardano.BM.Data.Tracer (annotateConfidential, emptyObject,
+                     mkObject, nullTracer, severityNotice, trStructured)
 import           Cardano.BM.Data.SubTrace
 import           Cardano.BM.Backend.Switchboard (MockSwitchboard (..))
 import qualified Cardano.BM.Setup as Setup
@@ -92,6 +88,11 @@ instance Transformable Text IO Pet where
         meta <- mkLOMeta Info Public
         traceWith tr $ LogObject "pet" meta $ (LogMessage . pack . show) pet
     trTransformer _ _verb _tr = nullTracer
+
+-- | default privacy annotation: Public
+instance DefinePrivacyAnnotation Pet
+-- | default severity: Debug
+instance DefineSeverity Pet
 
 
 logStructured :: Assertion


### PR DESCRIPTION

description
-----------

- [x] these classes allow us to indicate the default privacy annotation and severity level that a traced observable of a specific type will get when it is transformed to a LogObject 


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
