### PR TITLE
Tracer transformers on annotations

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -33,6 +33,7 @@ module Cardano.BM.Data.Tracer
     , condTracing
     , condTracingM
     -- * severity transformers
+    , setSeverity
     , severityDebug
     , severityInfo
     , severityNotice

--- a/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
@@ -19,8 +19,7 @@ import           Data.Text (Text, pack)
 import           Cardano.BM.Configuration.Static
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Tracing hiding (setupTrace)
-import           Cardano.BM.Data.Tracer (annotateConfidential, emptyObject,
-                     mkObject, nullTracer, severityNotice, trStructured)
+import           Cardano.BM.Data.Tracer
 import           Cardano.BM.Data.SubTrace
 import           Cardano.BM.Backend.Switchboard (MockSwitchboard (..))
 import qualified Cardano.BM.Setup as Setup
@@ -37,6 +36,7 @@ tests :: TestTree
 tests = testGroup "Testing Structured Logging" [
               testCase "logging simple text" logSimpleText
             , testCase "logging data structures" logStructured
+            , testCase "logging with filtering" logFiltered
             , testCase "logging data structures (stdout)" logStructuredStdout
             ]
 
@@ -145,5 +145,55 @@ logStructuredStdout = do
 \subsubsection{Structured logging with filtering}\label{code:logFiltered}
 
 \begin{code}
+
+data Material = Material { description :: Text, weight :: Int}
+           deriving (Show)
+
+instance ToObject Material where
+    toObject MinimalVerbosity _ = emptyObject -- do not log
+    toObject NormalVerbosity (Material n _) =
+        mkObject [ "kind" .= String "Material"
+                 , "description" .= toJSON n ]
+    toObject MaximalVerbosity (Material n a) =
+        mkObject [ "kind" .= String "Material"
+                 , "description" .= toJSON n
+                 , "weight" .= toJSON a ]
+
+instance Transformable Text IO Material where
+    -- transform to JSON Object
+    trTransformer StructuredLogging verb tr = trStructured verb tr
+    -- transform to textual representation using |show|
+    trTransformer TextualRepresentation _v tr = Tracer $ \mat -> do
+        meta <- mkLOMeta Info Public
+        traceWith tr $ LogObject "material" meta $ (LogMessage . pack . show) mat
+    trTransformer _ _verb _tr = nullTracer
+
+instance DefinePrivacyAnnotation Material where
+    definePrivacyAnnotation _ = Confidential
+instance DefineSeverity Material where
+    defineSeverity _ = Info
+
+logFiltered :: Assertion
+logFiltered = do
+    cfg <- defaultConfigStdout
+    msgs <- STM.newTVarIO []
+    baseTrace <- setupTrace $ TraceConfiguration cfg (MockSB msgs) "logStructured" Neutral
+
+    let stone = Material "stone" 1400
+        water = Material "H2O" 1000
+        confidentialTracer = annotatePrivacyAnnotation
+                             $ filterPrivacyAnnotation (pure Confidential)
+                             $ toLogObject $ baseTrace
+        infoTracer = annotateSeverity
+                     $ filterSeverity (pure Info)
+                     $ toLogObject $ baseTrace
+    traceWith confidentialTracer stone
+    traceWith infoTracer water
+
+    ms <- STM.readTVarIO msgs
+
+    assertBool
+        ("assert number of messages traced == 2: " ++ (show $ length ms))
+        (2 == length ms)
 
 \end{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
@@ -141,3 +141,9 @@ logStructuredStdout = do
     assertBool "OK" True
 
 \end{code}
+
+\subsubsection{Structured logging with filtering}\label{code:logFiltered}
+
+\begin{code}
+
+\end{code}


### PR DESCRIPTION
description
-----------

- [x] annotations "WithSeverity" and "WithPrivacyAnnotation" can be used to filter traced observables


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [x] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
