### PR TITLE
Supply a null Representation (& derived nullSetup)

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -14,6 +14,7 @@ module Cardano.BM.Configuration.Model
     ( Configuration (..)
     , ConfigurationInternal (..)
     , setup
+    , nullSetup
     , setupFromRepresentation
     , toRepresentation
     , exportConfiguration
@@ -423,6 +424,9 @@ setup :: FilePath -> IO Configuration
 setup fp = do
     r <- R.parseRepresentation fp
     setupFromRepresentation r
+
+nullSetup :: IO Configuration
+nullSetup = setupFromRepresentation R.nullRepresentation
 
 parseMonitors :: Maybe (HM.HashMap Text Value) -> HM.HashMap LoggerName (MEvPreCond, MEvExpr, [MEvAction])
 parseMonitors Nothing = HM.empty

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -17,6 +17,7 @@ module Cardano.BM.Data.Configuration
   (
     Representation (..)
   , Port
+  , nullRepresentation
   , parseRepresentation
   )
   where
@@ -54,6 +55,27 @@ data Representation = Representation
     }
     deriving (Generic, Show, ToJSON, FromJSON)
 
+\end{code}
+
+\subsubsection{nullRepresentation}\label{code:nullRepresentation}\index{nullRepresentation}
+
+Represent a mute logging configuration.
+\begin{code}
+nullRepresentation :: Representation
+nullRepresentation = Representation
+    { minSeverity     = Emergency -- Perhaps we want a 'Mute' severity?
+    , rotation        = Nothing
+    , setupScribes    = []
+    , defaultScribes  = []
+    , setupBackends   = []
+    , defaultBackends = []
+    , hasEKG          = Nothing
+    , hasGraylog      = Nothing
+    , hasPrometheus   = Nothing
+    , hasGUI          = Nothing
+    , logOutput       = Nothing
+    , options         = mempty
+    }
 \end{code}
 
 \subsubsection{parseRepresentation}\label{code:parseRepresentation}\index{parseRepresentation}


### PR DESCRIPTION
Sometimes one wants a passive value (all logging/tracing tracing turned off) of `Cardano.BM.Configuration.Model.Configuration`, without supplying a config file.

For this we need a passive value of `Cardano.BM.Data.Configuration.Representation`,
which this PR supplies -- accompanied with a `nullSetup` that provides a `Configuration` value.

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
