### PR TITLE
Add a pure parser for Representation type

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -421,7 +421,7 @@ after refinement.
 \begin{code}
 setup :: FilePath -> IO Configuration
 setup fp = do
-    r <- R.parseRepresentation fp
+    r <- R.readRepresentation fp
     setupFromRepresentation r
 
 parseMonitors :: Maybe (HM.HashMap Text Value) -> HM.HashMap LoggerName (MEvPreCond, MEvExpr, [MEvAction])

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -17,7 +17,6 @@ module Cardano.BM.Data.Configuration
   (
     Representation (..)
   , Port
-  , parseRepresentation
   , readRepresentation
   )
   where
@@ -60,7 +59,7 @@ data Representation = Representation
 
 \end{code}
 
-\subsubsection{readRepresentation}\label{code:parseRepresentation}\index{readRepresentation}
+\subsubsection{readRepresentation}\label{code:readRepresentation}\index{readRepresentation}
 \begin{code}
 readRepresentation :: FilePath -> IO Representation
 readRepresentation fp =

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -18,9 +18,13 @@ module Cardano.BM.Data.Configuration
     Representation (..)
   , Port
   , parseRepresentation
+  , readRepresentation
   )
   where
 
+import           Control.Exception (throwIO)
+import           Data.ByteString.Char8 (ByteString)
+import qualified Data.ByteString.Char8 as BS
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
 import qualified Data.Set as Set
@@ -56,14 +60,22 @@ data Representation = Representation
 
 \end{code}
 
-\subsubsection{parseRepresentation}\label{code:parseRepresentation}\index{parseRepresentation}
+\subsubsection{readRepresentation}\label{code:parseRepresentation}\index{readRepresentation}
 \begin{code}
-parseRepresentation :: FilePath -> IO Representation
-parseRepresentation fp = do
-    repr :: Representation <- decodeFileThrow fp
-    return $ implicit_fill_representation repr
+readRepresentation :: FilePath -> IO Representation
+readRepresentation fp =
+    either throwIO pure =<< parseRepresentation <$> BS.readFile fp
 
 \end{code}
+
+\subsubsection{parseRepresentation}\label{code:parseRepresentation}\index{parseRepresentation}
+\begin{code}
+parseRepresentation :: ByteString -> Either ParseException Representation
+parseRepresentation =
+    fmap implicit_fill_representation . decodeEither'
+
+\end{code}
+
 
 after parsing the configuration representation we implicitly correct it.
 \begin{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -370,7 +370,8 @@ unitConfigurationExport :: Assertion
 unitConfigurationExport = do
     cfg  <- setup "test/config.yaml"
 
-    cfg' <- withSystemTempFile "config.yaml-1213" $ \file _ -> do
+    cfg' <- withSystemTempFile "config.yaml-1213" $ \file0 _ -> do
+                let file = file0 <> "-copy"
                 exportConfiguration cfg file
                 setup file
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -147,7 +147,7 @@ unitConfigurationStaticRepresentation =
 
 unitConfigurationParsedRepresentation :: Assertion
 unitConfigurationParsedRepresentation = do
-    repr <- parseRepresentation "test/config.yaml"
+    repr <- readRepresentation "test/config.yaml"
     encode repr @?=
         (intercalate "\n"
             [ "rotation:"


### PR DESCRIPTION
Rename 'parseRepresentation' to 'readRepresentation' to free up the 'parseRepresentation' name for the pure parser.

The pure parser is useful on its own as well as being easier to test than a file reader function.
