### PR TITLE
Expose parseRepresentation function

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -17,6 +17,7 @@ module Cardano.BM.Data.Configuration
   (
     Representation (..)
   , Port
+  , parseRepresentation
   , readRepresentation
   )
   where


### PR DESCRIPTION
This was added (and exposed) in PR #454, but then hidden in a follow up commit 8a076afa4476bb6cb8914b0ecce5835ab2f9b1a0. This PR re-exposes it so it can be used outside this project.