### PR TITLE
prometheus backend: allow binding on addresses other than 127.0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-logs/
+>logs/
 dist
 dist-*
 cabal-dev
+*~
+\#*
 *.o
 *.hi
 *.chi
@@ -23,8 +25,11 @@ cabal.project.local~
 .ghc.environment.*
 .DS_Store
 .liquid/
+/logs
 
 /docs/*
 
 /result*
 .stack-to-nix.cache
+
+.dir-locals.el

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -190,7 +190,7 @@ prepare_configuration = do
     -- then it will try to open this pipe to forward messages to another process
     CM.setLogOutput c "logs/log-pipe"
 
-    CM.setPrometheusPort c 12800
+    CM.setPrometheusBindAddr c $ Just ("localhost", 12800)
     CM.setGUIport c 13790
     CM.setMonitors c $ HM.fromList
         [ ( "complex.monitoring"

--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -20,7 +20,7 @@ module Cardano.BM.Configuration
     , CM.setSubTrace
     , CM.getEKGport
     , CM.getGraylogPort
-    , CM.getPrometheusPort
+    , CM.getPrometheusBindAddr
     , CM.getGUIport
     , CM.getMonitors
     , getOptionOrDefault

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -17,6 +17,7 @@ module Cardano.BM.Data.Configuration
   (
     Representation (..)
   , Port
+  , HostPort
   , parseRepresentation
   , readRepresentation
   )
@@ -42,6 +43,7 @@ import           Cardano.BM.Data.Rotation
 \subsubsection{Representation}\label{code:Representation}\index{Representation}\label{code:Port}\index{Port}
 \begin{code}
 type Port = Int
+type HostPort = (String, Port)
 data Representation = Representation
     { minSeverity     :: Severity
     , rotation        :: Maybe RotationParameters
@@ -51,7 +53,7 @@ data Representation = Representation
     , defaultBackends :: [BackendKind]
     , hasEKG          :: Maybe Port
     , hasGraylog      :: Maybe Port
-    , hasPrometheus   :: Maybe Port
+    , hasPrometheus   :: Maybe HostPort
     , hasGUI          :: Maybe Port
     , logOutput       :: Maybe FilePath
     , options         :: HM.HashMap Text Object

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -103,7 +103,7 @@ unitConfigurationStaticRepresentation =
             , hasGUI = Just 12789
             , hasGraylog = Just 12788
             , hasEKG = Just 18321
-            , hasPrometheus = Just 12799
+            , hasPrometheus = Just ("localhost", 12799)
             , logOutput = Nothing
             , options =
                 HM.fromList [ ("test1", (HM.singleton "value" "object1"))
@@ -121,7 +121,9 @@ unitConfigurationStaticRepresentation =
             , "setupBackends:"
             , "- EKGViewBK"
             , "- KatipBK"
-            , "hasPrometheus: 12799"
+            , "hasPrometheus:"
+            , "- localhost"
+            , "- 12799"
             , "hasGraylog: 12788"
             , "hasGUI: 12789"
             , "defaultScribes:"
@@ -361,7 +363,7 @@ unitConfigurationParsed = do
                                             ]
         , cgPortEKG           = 12789
         , cgPortGraylog       = 12788
-        , cgPortPrometheus    = 12799 -- the default value
+        , cgBindAddrPrometheus = Just ("127.0.0.1", 12799) -- the default value
         , cgPortGUI           = 0
         , cgLogOutput         = Nothing
         }

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,49 @@
-with (import <nixpkgs> {});
-stdenv.mkDerivation {
-  name = "srcEnv";
-  nativeBuildInputs = [ cabal-install
-                        haskellPackages.ghcid
-                        zlib libiconv
-                        ghc
-                        cabal2nix
-                        stack
-                        numactl
-                      ];
-  buildInputs = [
-                ];
-}
+{ withHoogle ? true
+, localLib ? import ./lib.nix
+}:
+let
+  pkgs = localLib.iohkNix.pkgs;
+  default = import ./default.nix {};
+  devops = pkgs.stdenv.mkDerivation {
+    name = "devops-shell";
+    buildInputs = [
+      localLib.niv
+    ];
+    shellHook = ''
+      echo "DevOps Tools" \
+      | ${pkgs.figlet}/bin/figlet -f banner -c \
+      | ${pkgs.lolcat}/bin/lolcat
+
+      echo "NOTE: you may need to export GITHUB_TOKEN if you hit rate limits with niv"
+      echo "Commands:
+        * niv update <package> - update package
+
+      "
+    '';
+  };
+in
+default.nix-tools._raw.shellFor {
+  packages    = ps: with ps; [
+    lobemo-backend-aggregation
+    lobemo-backend-editor
+    lobemo-backend-ekg
+    lobemo-backend-graylog
+    lobemo-backend-monitoring
+    lobemo-examples
+    lobemo-scribe-systemd
+  ];
+  withHoogle  = withHoogle;
+  buildInputs =
+  (with default.nix-tools._raw; [
+    cabal-install.components.exes.cabal
+    ghcid.components.exes.ghcid
+  ]) ++
+  (with default.nix-tools._raw._config._module.args.pkgs; [
+    tmux
+    zlib
+    libiconv
+    cabal2nix
+    stack
+    numactl
+  ]);
+} // { inherit devops; }


### PR DESCRIPTION
issue: https://github.com/input-output-hk/iohk-monitoring-framework/issues/458

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
