### PR TITLE
Add `Read` instance to `TracingVerbosity`

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -205,7 +205,7 @@ The tracing verbosity will be passed to instances of |ToObject| for rendering
 the traced item accordingly.
 \begin{code}
 data TracingVerbosity = MinimalVerbosity | NormalVerbosity | MaximalVerbosity
-                        deriving (Eq, Ord)
+                        deriving (Eq, Read, Ord)
 
 \end{code}
 


### PR DESCRIPTION
`cardano-node` needs this  in order to decode the `TracingVerbosity` from the config `.yaml` files.