### PR TITLE
Control.Tracer.Transformers.Synopsizer:  elide repeated messages, with a summary

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -59,6 +59,7 @@ import qualified Cardano.BM.Observer.STM as STM
 import           Cardano.BM.Plugin
 import           Cardano.BM.Setup
 import           Cardano.BM.Trace
+import           Control.Tracer.Transformers.Synopsizer
 
 \end{code}
 
@@ -343,9 +344,9 @@ msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
       overflowTest :: Eq a => (Int, LogObject a) -> LogObject a -> Bool
-      overflowTest (count, prevLo) thisLo =
-        count == 2 || not (prevLo `loContentEq` thisLo)
-  synopsized <- mkSynopsizedTrace overflowTest trace'
+      overflowTest (counter, prevLo) thisLo =
+        counter == 2 || not (prevLo `loContentEq` thisLo)
+  synopsized <- mkSynopsizer overflowTest (liftSynopsized trace')
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -343,7 +343,7 @@ msgThr :: Trace IO Text -> IO (Async.Async ())
 msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
-  synopsized <- mkSynopsizer loContentEq trace'
+  synopsized <- mkSynopsizer loContentEq 3 trace'
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -343,10 +343,10 @@ msgThr :: Trace IO Text -> IO (Async.Async ())
 msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
-      overflowTest :: Eq a => (Int, LogObject a) -> LogObject a -> Bool
-      overflowTest (counter, prevLo) thisLo =
+      resetTest :: Eq a => (Int, LogObject a) -> LogObject a -> Bool
+      resetTest (counter, prevLo) thisLo =
         counter == 2 || not (prevLo `loContentEq` thisLo)
-  synopsized <- mkSynopsizer overflowTest (liftSynopsized trace')
+  synopsized <- mkSynopsizer resetTest (liftSynopsized trace')
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -59,6 +59,8 @@ import           Cardano.BM.Plugin
 import           Cardano.BM.Setup
 import           Cardano.BM.Trace
 
+import           Control.Tracer.Transformers.Synopsizer
+
 \end{code}
 
 \subsubsection{Define configuration}
@@ -341,12 +343,26 @@ msgThr :: Trace IO Text -> IO (Async.Async ())
 msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
-  Async.async (loop trace')
+  synopsized <- mkSynopsizer loContentEq trace'
+  Async.async (loop synopsized)
   where
     loop tr = do
         threadDelay 3000000  -- 3 seconds
         logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
+        logNotice tr "N O T I F I C A T I O N ! ! !"
         logDebug tr "a detailed debug message."
+        logError tr "Boooommm .."
+        logError tr "Boooommm .."
+        logError tr "Boooommm .."
         logError tr "Boooommm .."
         loop tr
 #endif

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -342,7 +342,10 @@ msgThr :: Trace IO Text -> IO (Async.Async ())
 msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
-  synopsized <- mkSynopsizedTrace loContentEq 3 trace'
+      overflowTest :: Eq a => (Int, LogObject a) -> LogObject a -> Bool
+      overflowTest (count, prevLo) thisLo =
+        count == 2 || not (prevLo `loContentEq` thisLo)
+  synopsized <- mkSynopsizedTrace overflowTest trace'
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -50,6 +50,7 @@ import           Cardano.BM.Data.Output
 import           Cardano.BM.Data.Rotation
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.SubTrace
+import           Cardano.BM.Data.Trace
 #ifdef ENABLE_OBSERVABLES
 import           Cardano.BM.Data.Observable
 import           Cardano.BM.Observer.Monadic (bracketObserveIO)
@@ -58,8 +59,6 @@ import qualified Cardano.BM.Observer.STM as STM
 import           Cardano.BM.Plugin
 import           Cardano.BM.Setup
 import           Cardano.BM.Trace
-
-import           Control.Tracer.Transformers.Synopsizer
 
 \end{code}
 
@@ -343,7 +342,7 @@ msgThr :: Trace IO Text -> IO (Async.Async ())
 msgThr trace = do
   logInfo trace "start messaging .."
   let trace' = appendName "message" trace
-  synopsized <- mkSynopsizer loContentEq 3 trace'
+  synopsized <- mkSynopsizedTrace loContentEq 3 trace'
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -54,6 +54,7 @@ executable example-complex
                        mtl,
                        random,
                        text,
+                       tracer-transformers,
                        unordered-containers
   if os(windows)
      build-depends:    Win32

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -63,8 +63,6 @@ library
                        Cardano.BM.Trace
                        Cardano.BM.Tracer
 
-                       Control.Tracer.Transformers.Synopsizer
-
   if !flag(disable-observables)
     exposed-modules:   Cardano.BM.Observer.Monadic
                        Cardano.BM.Observer.STM
@@ -105,6 +103,7 @@ library
                        text,
                        time,
                        time-units,
+                       tracer-transformers,
                        transformers,
                        unordered-containers,
                        vector,

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -138,6 +138,7 @@ test-suite tests
                        Cardano.BM.Test.Structured
                        Cardano.BM.Test.Tracer
                        Cardano.BM.Test.Aggregated
+                       Cardano.BM.Arbitrary
                        Cardano.BM.Arbitrary.Aggregated
 
   default-language:    Haskell2010

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -63,6 +63,8 @@ library
                        Cardano.BM.Trace
                        Cardano.BM.Tracer
 
+                       Control.Tracer.Transformers.Synopsizer
+
   if !flag(disable-observables)
     exposed-modules:   Cardano.BM.Observer.Monadic
                        Cardano.BM.Observer.STM
@@ -174,4 +176,3 @@ test-suite tests
 
   if !flag(disable-observables)
     cpp-options:       -DENABLE_OBSERVABLES
-

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -167,6 +167,7 @@ test-suite tests
                        text,
                        time,
                        time-units,
+                       tracer-transformers,
                        transformers,
                        unordered-containers,
                        vector,

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -248,6 +248,10 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      (severity lometa, text, maylo)
                                 (LogError text) ->
                                      (severity lometa, text, Nothing)
+                                (LogRepeats count) ->
+                                     ( severity lometa
+                                     , "Previous message from this thread was repeated " <> pack (show count) <> " times."
+                                     , Nothing)
                                 (LogStructured s) ->
                                      (severity lometa, TL.toStrict $ decodeUtf8 s, Nothing {-Just loitem-})
                                 (LogValue name value) ->

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -248,9 +248,9 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      (severity lometa, text, maylo)
                                 (LogError text) ->
                                      (severity lometa, text, Nothing)
-                                (LogRepeats count) ->
+                                (LogRepeats count _fir _las) ->
                                      ( severity lometa
-                                     , "Previous message from this thread was repeated " <> pack (show count) <> " times."
+                                     , "Similar messages elided, " <> pack (show count) <> " total."
                                      , Nothing)
                                 (LogStructured s) ->
                                      (severity lometa, TL.toStrict $ decodeUtf8 s, Nothing {-Just loitem-})

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -204,6 +204,7 @@ data LOContent a = LogMessage a
                  | Command CommandValue
                  | KillPill
                  deriving (Show, Eq)
+-- WARNING: update 'locTypeEq' when extending this!
 
 instance ToJSON a => ToJSON (LOContent a) where
     toJSON (LogMessage m) =
@@ -272,6 +273,7 @@ instance (FromJSON a) => FromJSON (LOContent a) where
 loType :: LogObject a -> Text
 loType (LogObject _ _ content) = loType2Name content
 
+-- | Equality between LogObjects based on their log content types.
 loTypeEq :: LogObject a -> LogObject a -> Bool
 loTypeEq = locTypeEq `on` loContent
 
@@ -389,6 +391,7 @@ mapLOContent f = \case
     Command v            -> Command v
     KillPill             -> KillPill
 
+-- | Equality between LogObjects based on their log content values.
 loContentEq :: Eq a => LogObject a -> LogObject a -> Bool
 loContentEq = (==) `on` loContent
 

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -13,8 +13,10 @@ module Cardano.BM.Data.LogItem
   ( LogObject (..)
   , loType
   , loType2Name
+  , loTypeEq
   , LOMeta (..), mkLOMeta
   , LOContent (..)
+  , locTypeEq
   , CommandValue (..)
   , LoggerName
   , MonitorAction (..)
@@ -23,6 +25,7 @@ module Cardano.BM.Data.LogItem
   , utc2ns
   , mapLogObject
   , mapLOContent
+  , loContentEq
   , lo2name
   , loname2text
   )
@@ -36,6 +39,7 @@ import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.=),
 import           Data.Aeson.Types (Parser)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Base64.Lazy as BS64
+import           Data.Function (on)
 import           Data.Text (Text, pack, stripPrefix)
 import qualified Data.Text.Lazy as LT
 import           Data.Text.Lazy.Encoding (encodeUtf8, decodeUtf8)
@@ -189,6 +193,7 @@ Payload of a |LogObject|:
 \begin{code}
 data LOContent a = LogMessage a
                  | LogError Text
+                 | LogRepeats Int
                  | LogValue Text Measurable
                  | LogStructured BS.ByteString
                  | ObserveOpen CounterState
@@ -207,6 +212,9 @@ instance ToJSON a => ToJSON (LOContent a) where
     toJSON (LogError m) =
         object [ "kind" .= String "LogError"
                , "message" .= toJSON m]
+    toJSON (LogRepeats n) =
+        object [ "kind" .= String "LogRepeats"
+               , "elided-count" .= toJSON n]
     toJSON (LogValue n v) =
         object [ "kind" .= String "LogValue"
                , "name" .= toJSON n
@@ -241,6 +249,7 @@ instance (FromJSON a) => FromJSON (LOContent a) where
                   >>=
                   \case "LogMessage" -> LogMessage <$> v .: "message"
                         "LogError" -> LogError <$> v .: "message"
+                        "LogRepeats" -> LogRepeats <$> v .: "elided-count"
                         "LogValue" -> LogValue <$> v .: "name" <*> v .: "value"
                         "LogStructured" -> LogStructured <$>
                                               BS64.decodeLenient <$>
@@ -263,6 +272,24 @@ instance (FromJSON a) => FromJSON (LOContent a) where
 loType :: LogObject a -> Text
 loType (LogObject _ _ content) = loType2Name content
 
+loTypeEq :: LogObject a -> LogObject a -> Bool
+loTypeEq = locTypeEq `on` loContent
+
+locTypeEq :: LOContent a -> LOContent a -> Bool
+locTypeEq LogMessage{}        LogMessage{}        = True
+locTypeEq LogError{}          LogError{}          = True
+locTypeEq LogRepeats{}        LogRepeats{}        = True
+locTypeEq LogValue{}          LogValue{}          = True
+locTypeEq LogStructured{}     LogStructured{}     = True
+locTypeEq ObserveOpen{}       ObserveOpen{}       = True
+locTypeEq ObserveDiff{}       ObserveDiff{}       = True
+locTypeEq ObserveClose{}      ObserveClose{}      = True
+locTypeEq AggregatedMessage{} AggregatedMessage{} = True
+locTypeEq MonitoringEffect{}  MonitoringEffect{}  = True
+locTypeEq Command{}           Command{}           = True
+locTypeEq KillPill{}          KillPill{}          = True
+locTypeEq _ _ = False
+
 \end{code}
 
 Name of a message content type
@@ -271,6 +298,7 @@ loType2Name :: LOContent a -> Text
 loType2Name = \case
     LogMessage _        -> "LogMessage"
     LogError _          -> "LogError"
+    LogRepeats _        -> "LogRepeats"
     LogValue _ _        -> "LogValue"
     LogStructured _     -> "LogStructured"
     ObserveOpen _       -> "ObserveOpen"
@@ -350,6 +378,7 @@ mapLOContent :: (a -> b) -> LOContent a -> LOContent b
 mapLOContent f = \case
     LogMessage msg       -> LogMessage (f msg)
     LogError a           -> LogError a
+    LogRepeats n         -> LogRepeats n
     LogStructured m      -> LogStructured m
     LogValue n v         -> LogValue n v
     ObserveOpen st       -> ObserveOpen st
@@ -359,6 +388,9 @@ mapLOContent f = \case
     MonitoringEffect act -> MonitoringEffect act
     Command v            -> Command v
     KillPill             -> KillPill
+
+loContentEq :: Eq a => LogObject a -> LogObject a -> Bool
+loContentEq = (==) `on` loContent
 
 \end{code}
 

--- a/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
@@ -4,13 +4,27 @@
 
 %if style == newcode
 \begin{code}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Cardano.BM.Data.Trace
   ( Trace
+  , mkSynopsizedTrace
   )
   where
 
-import           Cardano.BM.Data.LogItem (LogObject)
-import           Cardano.BM.Data.Tracer (Tracer)
+import           Control.Monad.IO.Class (MonadIO)
+
+import           Cardano.BM.Data.LogItem
+                     ( LOContent(..), LOMeta(..)
+                     , LogObject(..), LoggerName, PrivacyAnnotation
+                     , mkLOMeta)
+import           Cardano.BM.Data.Severity (Severity)
+import           Cardano.BM.Data.Tracer (Tracer(..), traceWith)
+
+import           Control.Tracer.Transformers.Synopsizer
+                     (Synopsized(..), mkSynopsizer)
 
 \end{code}
 %endif
@@ -20,4 +34,44 @@ A |Trace m a| is a |Tracer m (LogObject a)|.
 \begin{code}
 
 type Trace m a = Tracer m (LogObject a)
+\end{code}
+
+\subsubsection{Transformer for synopsization}
+\label{code:mkSynopsizedTrace}
+\index{mkSynopsizedTrace}
+Build upon |Synopsizer| tracer transformer to suppress repeated messages,
+based on a given transitive similarity criterion.
+
+A summary is printed every |overflow| entries, and at the end of a run
+of similar messages.
+
+Handy predicates to use:  'loTypeEq' and 'loContentEq'.
+
+See the caveats in the |Synopsizer| tracer transformer description.
+\begin{code}
+
+mkSynopsizedTrace
+  :: forall m a. MonadIO m
+  => (LogObject a -> LogObject a -> Bool)
+  -> Int
+  -> Trace m a
+  -> m (Trace m a)
+mkSynopsizedTrace similarity overflow tr =
+  mkSynopsizer similarity overflow (transform tr)
+ where
+   transform :: Trace m a -> Tracer m (Synopsized (LogObject a))
+   transform trace = Tracer $ \case
+       One    a -> traceWith   trace   a
+       Many n a -> traceRepeat trace n a
+
+   traceLOC :: Trace m a -> [LoggerName] -> Severity -> PrivacyAnnotation -> LOContent a -> m ()
+   traceLOC t name sev' priv' a = do
+     meta <- mkLOMeta sev' priv'
+     traceWith t $ LogObject name meta a
+
+   traceRepeat :: Trace m a -> Int -> LogObject a -> m ()
+   traceRepeat t repeats prev =
+     traceLOC t ["synopsis"] (severity $ loMeta prev) (privacy $ loMeta prev) $
+       LogRepeats repeats
+
 \end{code}

--- a/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -40,15 +40,18 @@ data SynopsizerState a
     }
 
 -- | Generic Trace transformer.  Will omit consequent runs of similar log objects,
---   with similarity defined by supplied predicate.  When a run of similar log
+--   with similarity defined by a supplied predicate.  When a run of similar log
 --   objects is terminated by a dissimilar one, a summary of omitted objects is
 --   emitted as a log object with same severity and privacy as the first object.
 --
 --   Handy predicates to use:  'loTypeEq' and 'loContentEq'.
 --
---   Caveat:  the resulting trace has state, which is lost upon trace's termination.
+--   Caveat 1:  the supplied criterion is expected to define a transitive relation.
+--
+--   Caveat 2:  the resulting trace has state, which is lost upon trace's termination.
 --   This means that if the trace ends with a run of similar messages, this will
---   not be reflected in the trace itself, as observed by the backends.
+--   not be reflected in the trace itself, as observed by the backends
+--   -- they'll only receive the first message of the run.
 --
 --   WARNING:  the resulting tracer is not thread-safe!
 mkSynopsizer :: forall m a

--- a/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -1,0 +1,88 @@
+\label{code:Control.Tracer.Transformers.WithThreadAndTime}
+
+%if style == newcode
+\begin{code}
+{-|
+Module: Synopsizer
+
+Synopsize runs of repeated events, as an initial message with a summary at the end.
+-}
+{-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE MultiWayIf     #-}
+{-# LANGUAGE RankNTypes     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Tracer.Transformers.Synopsizer
+    (
+    -- * transformer
+      mkSynopsizer
+    ) where
+
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.IORef (newIORef,readIORef, writeIORef)
+
+import           Cardano.BM.Trace
+import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Severity
+import           Control.Tracer (Tracer (..), traceWith)
+
+\end{code}
+%endif
+
+\begin{code}
+-- | State required to track and summarise repeats.
+data SynopsizerState a
+  = SynopsizerState
+    { ssRepeats  :: {-# UNPACK #-} !Int
+    , ssLast     :: !(Maybe (LogObject a))
+    }
+
+-- | Generic Trace transformer.  Will omit consequent runs of similar log objects,
+--   with similarity defined by supplied predicate.  When a run of similar log
+--   objects is terminated by a dissimilar one, a summary of omitted objects is
+--   emitted as a log object with same severity and privacy as the first object.
+--
+--   Handy predicates to use:  'loTypeEq' and 'loContentEq'.
+--
+--   WARNING:  the resulting tracer is not thread-safe!
+mkSynopsizer :: forall m a
+              . (MonadIO m)
+             => (LogObject a -> LogObject a -> Bool)
+             -> Trace m a -> m (Trace m a)
+mkSynopsizer matchTest tr =
+  (liftIO . newIORef $ SynopsizerState 0 Nothing)
+  >>= pure . go
+  where
+    go s = Tracer $ \a -> do
+      ss  <- liftIO $ readIORef s
+      ss' <- case ssLast ss of
+        Nothing -> do
+          traceWith tr a
+          pure ss { ssRepeats = 0, ssLast = Just a }
+        Just prev ->
+          if | prev `matchTest` a
+             -> pure ss { ssRepeats = ssRepeats ss + 1 }
+
+             | ssRepeats ss == 0
+             -> traceWith tr a >>
+                pure ss { ssLast = Just a }
+
+             | otherwise
+             -> traceRepeat (ssRepeats ss) prev >>
+                traceWith tr a >>
+                pure ss { ssRepeats = 0, ssLast = Just a }
+      liftIO $ writeIORef s ss'
+
+    traceLOC :: [LoggerName] -> Severity -> PrivacyAnnotation -> LOContent a -> m ()
+    traceLOC name sev' priv' a = do
+      meta <- mkLOMeta sev' priv'
+      traceWith tr $ LogObject name meta a
+
+    traceRepeat :: Int -> LogObject a -> m ()
+    traceRepeat repeats prev =
+      traceLOC ["synopsis"] (severity $ loMeta prev) (privacy $ loMeta prev) $
+        LogRepeats repeats
+
+\end{code}

--- a/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/iohk-monitoring/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -46,6 +46,10 @@ data SynopsizerState a
 --
 --   Handy predicates to use:  'loTypeEq' and 'loContentEq'.
 --
+--   Caveat:  the resulting trace has state, which is lost upon trace's termination.
+--   This means that if the trace ends with a run of similar messages, this will
+--   not be reflected in the trace itself, as observed by the backends.
+--
 --   WARNING:  the resulting tracer is not thread-safe!
 mkSynopsizer :: forall m a
               . (MonadIO m)

--- a/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
+++ b/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
@@ -49,7 +49,7 @@ instance Arbitrary a => Arbitrary (LOContent a) where
   arbitrary = QC.oneof
     [ LogMessage <$> arbitrary
     , LogError <$> message
-    , LogRepeats <$> arbitrary
+    , LogRepeats <$> arbitrary <*> arbitrary <*> arbitrary
     , LogValue <$> message <*> arbitrary
     -- TODO:  fill this in later.
     -- , LogStructured <$> arbitrary

--- a/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
+++ b/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE NamedFieldPuns          #-}
 {-# LANGUAGE ScopedTypeVariables     #-}
-{-# LANGUAGE UndecidableInstances    #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -68,7 +67,7 @@ instance Arbitrary a => Arbitrary (LOContent a) where
       , "But what first motivated me wasn't anything I read. I just got mad seeing the machines ripping up the woods."
       ]
 
-instance Arbitrary (LOContent a) => Arbitrary (LogObject a) where
+instance Arbitrary a => Arbitrary (LogObject a) where
   arbitrary = do
     loName <- elements
       [ ["logger", "for", "nothing"]

--- a/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
+++ b/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE CPP                     #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE NamedFieldPuns          #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
+{-# LANGUAGE UndecidableInstances    #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.BM.Arbitrary
+  ()
+where
+
+import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+
+import           Cardano.BM.Data.Aggregated
+import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Severity
+
+import qualified Test.QuickCheck as QC
+import           Test.QuickCheck (arbitrary, elements)
+import           Test.QuickCheck.Arbitrary (Arbitrary)
+
+instance Arbitrary Severity where
+  arbitrary = elements $ enumFromTo minBound maxBound
+
+instance Arbitrary PrivacyAnnotation where
+  arbitrary = elements $ [Confidential, Public]
+
+instance Arbitrary LOMeta where
+  arbitrary = LOMeta
+    <$> pure (posixSecondsToUTCTime $ fromIntegral (1 :: Int))
+     -- ^ Not a very good choice for an arbitary timestamp.
+    <*> elements ["thread", "of", "conscience"]
+    <*> pure "localhost"
+    <*> arbitrary
+    <*> arbitrary
+
+instance Arbitrary Measurable where
+  arbitrary = QC.oneof
+    [ Microseconds <$> arbitrary
+    , Nanoseconds  <$> arbitrary
+    , Seconds      <$> arbitrary
+    , Bytes        <$> arbitrary
+    , PureD        <$> arbitrary
+    , PureI        <$> arbitrary
+    , Severity     <$> arbitrary
+    ]
+
+instance Arbitrary a => Arbitrary (LOContent a) where
+  arbitrary = QC.oneof
+    [ LogMessage <$> arbitrary
+    , LogError <$> message
+    , LogRepeats <$> arbitrary
+    , LogValue <$> message <*> arbitrary
+    -- TODO:  fill this in later.
+    -- , LogStructured <$> arbitrary
+    -- , ObserveOpen CounterState
+    -- , ObserveDiff CounterState
+    -- , ObserveClose CounterState
+    -- , AggregatedMessage [(Text, Aggregated)]
+    -- , MonitoringEffect MonitorAction
+    -- , Command CommandValue
+    , pure KillPill
+    ] where
+    message = elements
+      [ "There are three flowers in the vase. The third flower is yellow."
+      , "The sky above the port was the color of television, tuned to a dead channel."
+      , "But what first motivated me wasn't anything I read. I just got mad seeing the machines ripping up the woods."
+      ]
+
+instance Arbitrary (LOContent a) => Arbitrary (LogObject a) where
+  arbitrary = do
+    loName <- elements
+      [ ["logger", "for", "nothing"]
+      , ["tracer", "of"]
+      , ["things"]
+      ]
+    loMeta <- arbitrary
+    loContent :: LOContent a <- arbitrary
+    pure LogObject { loName, loMeta, loContent }

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -48,6 +48,7 @@ import           Cardano.BM.Data.Observable
 import           Cardano.BM.Data.Output
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.SubTrace
+import           Cardano.BM.Data.Trace
 #ifdef ENABLE_OBSERVABLES
 import           Cardano.BM.Counters (getMonoClock)
 import           Cardano.BM.Data.Aggregated
@@ -62,7 +63,6 @@ import           Cardano.BM.Trace (Trace, appendName, logDebug, logInfo,
 import           Cardano.BM.Test.Mock (MockSwitchboard (..), traceMock)
 
 import           Control.Tracer (contramap, traceWith)
-import           Control.Tracer.Transformers.Synopsizer (mkSynopsizer)
 
 import           Cardano.BM.Arbitrary ()
 
@@ -397,7 +397,7 @@ prop_synopsizer stream runLimit = runLimit > 1 QC.==> QC.monadicIO $ do
          (setupTrace $
            TraceConfiguration cfg (MockSB msgs) "test-synopsizer" Neutral)
 
-    tr <- QC.run $ mkSynopsizer equalityCriterion runLimit base
+    tr <- QC.run $ mkSynopsizedTrace equalityCriterion runLimit base
     QC.run $ mapM_ (traceWith tr) stream
 
     -- acquire the traced objects

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -384,7 +384,7 @@ unitTraceDuplicate = do
 
 \end{code}
 
-\subsubsection{Verify that Synopsizer has the intended effect on the message count.}\label{code:unitSynopsizer}
+\subsubsection{Verify that Synopsizer has the intended effect on the message count.}\label{code:prop_synopsizer}
 |Synopsizer| has a predictable effect on the message stream.
 
 \begin{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -63,6 +63,7 @@ import           Cardano.BM.Trace (Trace, appendName, logDebug, logInfo,
 import           Cardano.BM.Test.Mock (MockSwitchboard (..), traceMock)
 
 import           Control.Tracer (contramap, traceWith)
+import           Control.Tracer.Transformers.Synopsizer (mkSynopsizer)
 
 import           Cardano.BM.Arbitrary ()
 
@@ -398,7 +399,7 @@ prop_synopsizer stream runLimit = runLimit > 1 QC.==> QC.monadicIO $ do
          (setupTrace $
            TraceConfiguration cfg (MockSB msgs) "test-synopsizer" Neutral)
 
-    tr <- QC.run $ mkSynopsizedTrace overflowTest base
+    tr <- QC.run $ mkSynopsizer overflowTest (liftSynopsized base)
     QC.run $ mapM_ (traceWith tr) stream
 
     -- acquire the traced objects

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -116,6 +116,7 @@ unit_tests = testGroup "Unit tests" [
       , testCase "testing throwing of exceptions" unitExceptionThrowing
       , testCase "NoTrace: check lazy evaluation" unitTestLazyEvaluation
       , testCase "private messages should not be logged into private files" unitLoggingPrivate
+      , testProperty "synopsization edge case: everything similar & overflow is length-1" (QC.property $ \x -> prop_synopsizer [x, x, x, x] 3)
       , testProperty "synopsization shrinks the messeage stream predictably" prop_synopsizer
       ]
       where
@@ -441,7 +442,11 @@ synopsizerOracle criterion runLimit xs =
    -- | Compute the similarity runs:
    similarityRuns = filter (any id) $ group similarity
    -- | The last summary is withheld:
-   tailCorrection = if not (null similarity) && last similarity then 1 else 0
+   tailCorrection =
+     if not (null similarity)
+        && last similarity
+        && length (last similarityRuns) /= runLimit
+     then 1 else 0
 
 -- | Every 'limit' messages are going to get a summary, plus an optional tail,
 --   which might get either a summary or a plain message.

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -81,6 +81,7 @@
             (hsPkgs.text)
             (hsPkgs.time)
             (hsPkgs.time-units)
+            (hsPkgs.tracer-transformers)
             (hsPkgs.transformers)
             (hsPkgs.unordered-containers)
             (hsPkgs.vector)

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -43,6 +43,7 @@
           (hsPkgs.text)
           (hsPkgs.time)
           (hsPkgs.time-units)
+          (hsPkgs.tracer-transformers)
           (hsPkgs.transformers)
           (hsPkgs.unordered-containers)
           (hsPkgs.vector)

--- a/nix/.stack.nix/lobemo-examples.nix
+++ b/nix/.stack.nix/lobemo-examples.nix
@@ -44,6 +44,7 @@
             (hsPkgs.mtl)
             (hsPkgs.random)
             (hsPkgs.text)
+            (hsPkgs.tracer-transformers)
             (hsPkgs.unordered-containers)
             ] ++ (if system.isWindows
             then [ (hsPkgs.Win32) ]

--- a/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -1,4 +1,4 @@
-\label{code:Control.Tracer.Transformers.WithThreadAndTime}
+\label{code:Control.Tracer.Transformers.Synopsizer}
 
 %if style == newcode
 \begin{code}

--- a/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -22,7 +22,7 @@ module Control.Tracer.Transformers.Synopsizer
     ) where
 
 import           Control.Concurrent (MVar, newMVar, modifyMVarMasked)
-import           Control.Monad (mapM_, join)
+import           Control.Monad (join)
 import           Control.Monad.IO.Class (MonadIO (..))
 
 import           Control.Tracer (Tracer (..), traceWith)
@@ -87,10 +87,10 @@ mkSynopsizer overflowTest tr =
           if | (ssRepeats ss, fir) `overflowTest` a
              -> (,)
                (ss { ssRepeats = 0, ssFirst = Just a, ssLast = Just a })
-               (mapM_ (traceWith tr) $
-                [ Many (ssRepeats ss) fir las
-                | ssRepeats ss /= 0]
-                ++ [ One a ])
+               (if ssRepeats ss == 0
+                then traceWith tr (One a)
+                else traceWith tr (Many (ssRepeats ss) fir las) >>
+                     traceWith tr (One a))
 
              | otherwise
              -> (,)

--- a/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -79,8 +79,8 @@ mkSynopsizer matchTest overflow tr =
           pure ss { ssRepeats = 0, ssLast = Just a }
         Just prev ->
           if | prev `matchTest` a
-             -> if | ssRepeats ss == overflow
-                   -> traceWith tr (Many (ssRepeats ss) prev) >>
+             -> if | ssRepeats ss + 1 == overflow
+                   -> traceWith tr (Many (ssRepeats ss + 1) prev) >>
                       pure ss { ssRepeats = 0 }
 
                    | otherwise

--- a/tracer-transformers/tracer-transformers.cabal
+++ b/tracer-transformers/tracer-transformers.cabal
@@ -16,6 +16,7 @@ build-type:          Simple
 library
   hs-source-dirs:      src
   exposed-modules:     Control.Tracer.Transformers.ObserveOutcome
+                       Control.Tracer.Transformers.Synopsizer
                        Control.Tracer.Transformers.WithThreadAndTime
 
   default-extensions:  OverloadedStrings


### PR DESCRIPTION
issue: https://github.com/input-output-hk/iohk-monitoring-framework/issues/459

# TODO

- [x] Tests (decide on test plan).
- [x] Decide on whether we want an alternative to introducing a dependency on `iohk-monitoring` in `tracer-transformers`.  We currently have to do this, because we need a `Trace` (and not just a `Tracer`), to be able to inject a `LogRepeats` message to the stream.

# checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
