### PR TITLE
Fix stack overflow by adding a missing bang

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/MessageCounter.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/MessageCounter.lhs
@@ -38,7 +38,7 @@ Data structure holding essential info for message counters.
 \begin{code}
 data MessageCounter = MessageCounter
                         { mcStart       :: {-# UNPACK #-} !UTCTime
-                        , mcCountersMap :: HM.HashMap Text Word64
+                        , mcCountersMap :: !(HM.HashMap Text Word64)
                         }
                         deriving (Show)
 


### PR DESCRIPTION
The local `qProc` function in `Cardano.BM.Backend.Switchboard` loops by
calling itself recursively, passing in the same `MVar MessageCounter` each
time. However, `MessageCounter` was missing a bang on its `mcCountersMap`
field, which contains `HM.HashMap Text Word64`. Even though the `HashMap` is a
strict one, if you don't force it, you're still accumulating thunks. And as
the `MVar` containing the `MessageCounter` was passed recursively, this
resulted in a stack overflow instead of running out of (heap) memory.

Fix it by adding the missing bang.

This should fix https://github.com/input-output-hk/cardano-node/issues/370.