### PR TITLE
#482, cardano-node#414:  more transformers + flexibility

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -48,6 +48,7 @@ library
                        Cardano.BM.Data.SubTrace
                        Cardano.BM.Data.Trace
                        Cardano.BM.Data.Tracer
+                       Cardano.BM.Data.Transformers
                        Cardano.BM.Tracing
 
                        Cardano.BM.Backend.ExternalAbstraction

--- a/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
@@ -10,20 +10,11 @@
 
 module Cardano.BM.Data.Trace
   ( Trace
-  , liftSynopsized
   )
   where
 
-import           Control.Monad.IO.Class (MonadIO)
-
-import           Cardano.BM.Data.LogItem
-                     ( LOContent(..), LOMeta(..)
-                     , LogObject(..)
-                     , mkLOMeta)
-import           Cardano.BM.Data.Tracer (Tracer(..), traceWith)
-
-import           Control.Tracer.Transformers.Synopsizer
-                     (Synopsized(..))
+import           Cardano.BM.Data.LogItem (LogObject(..))
+import           Cardano.BM.Data.Tracer (Tracer(..))
 
 \end{code}
 %endif
@@ -33,26 +24,4 @@ A |Trace m a| is a |Tracer m (LogObject a)|.
 \begin{code}
 
 type Trace m a = Tracer m (LogObject a)
-\end{code}
-
-\subsubsection{Transformer for synopsization}
-\label{code:liftSynopsized}
-\index{liftSynopsized}
-Make a |Trace| |Synopsized|.
-\begin{code}
-
-liftSynopsized
-  :: forall m a. MonadIO m
-  => Trace m a
-  -> Tracer m (Synopsized (LogObject a))
-liftSynopsized tr =
-  Tracer $ \case
-    One    a       -> traceWith   tr   a
-    Many n fir las -> traceRepeat tr n fir las
- where
-   traceRepeat :: Trace m a -> Int -> LogObject a -> LogObject a -> m ()
-   traceRepeat t repeats fir las = do
-     meta <- mkLOMeta (severity $ loMeta fir) (privacy $ loMeta fir)
-     traceWith t . LogObject ["synopsis"] meta $ LogRepeats repeats fir las
-
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Data/Transformers.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Transformers.lhs
@@ -1,0 +1,92 @@
+\subsection{Cardano.BM.Data.Transformers}
+\label{code:Cardano.BM.Data.Transformers}
+
+%if style == newcode
+\begin{code}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.BM.Data.Transformers
+  ( liftCounting
+  , liftFolding
+  , liftSynopsized
+  )
+  where
+
+import           Control.Monad.IO.Class (MonadIO)
+
+import           Data.Text (Text)
+
+import           Cardano.BM.Data.Aggregated (Measurable(..))
+import           Cardano.BM.Data.LogItem
+                     ( LOContent(..), LOMeta(..)
+                     , LogObject(..), LoggerName
+                     , mkLOMeta)
+import           Cardano.BM.Data.Tracer (Tracer(..), traceWith)
+import           Cardano.BM.Data.Trace
+
+import           Control.Tracer.Transformers
+import           Control.Tracer.Transformers.Synopsizer
+                     (Synopsized(..))
+\end{code}
+
+\subsubsection{Transformer for counting events}
+\label{code:liftCounting}
+\index{liftCounting}
+Lift a 'Counting' tracer into a 'Trace' of 'PureI' messages.
+\begin{code}
+
+liftCounting
+  :: forall m a
+  .  LOMeta -> [LoggerName] -> Text -> Trace m a
+  -> Tracer m (Counting (LogObject a))
+liftCounting meta name desc tr = Tracer (traceIncrement tr)
+ where
+   traceIncrement :: Trace m a -> Counting (LogObject a) -> m ()
+   traceIncrement t (Counting n) =
+     traceWith t . LogObject name meta . LogValue desc . PureI $ fromIntegral n
+
+\end{code}
+
+\subsubsection{Transformer for state folding}
+\label{code:liftFolding}
+\index{liftFolding}
+Lift a 'Trace' tracer into a 'Trace' of 'PureI' messages,
+thereby specialising it to 'Integral'.
+\begin{code}
+
+liftFolding
+  :: forall m f a
+  .  (Integral f) -- TODO:  generalise
+  => LOMeta -> [LoggerName] -> Text -> Trace m a
+  -> Tracer m (Folding (LogObject a) f)
+liftFolding meta name desc tr = Tracer (traceIncrement tr)
+ where
+   traceIncrement :: Trace m a -> Folding (LogObject a) f -> m ()
+   traceIncrement t (Folding f) =
+     traceWith t . LogObject name meta . LogValue desc . PureI $ fromIntegral f
+
+\end{code}
+
+\subsubsection{Transformer for synopsization}
+\label{code:liftSynopsized}
+\index{liftSynopsized}
+Make a |Trace| |Synopsized|.
+\begin{code}
+
+liftSynopsized
+  :: forall m a. MonadIO m
+  => Trace m a
+  -> Tracer m (Synopsized (LogObject a))
+liftSynopsized tr =
+  Tracer $ \case
+    One    a       -> traceWith   tr   a
+    Many n fir las -> traceRepeat tr n fir las
+ where
+   traceRepeat :: Trace m a -> Int -> LogObject a -> LogObject a -> m ()
+   traceRepeat t repeats fir las = do
+     meta <- mkLOMeta (severity $ loMeta fir) (privacy $ loMeta fir)
+     traceWith t . LogObject ["synopsis"] meta $ LogRepeats repeats fir las
+
+\end{code}

--- a/shell.nix
+++ b/shell.nix
@@ -32,6 +32,7 @@ default.nix-tools._raw.shellFor {
     lobemo-backend-monitoring
     lobemo-examples
     lobemo-scribe-systemd
+    tracer-transformers
   ];
   withHoogle  = withHoogle;
   buildInputs =

--- a/tracer-transformers/src/Control/Tracer/Transformers.hs
+++ b/tracer-transformers/src/Control/Tracer/Transformers.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+module Control.Tracer.Transformers
+  ( Counting(..)
+  , Folding(..)
+  , counting
+  , fanning
+  , folding
+  ) where
+
+import           Control.Monad (join)
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Data.IORef (IORef, newIORef, atomicModifyIORef')
+
+import           Control.Tracer
+
+-- | A pure tracer combinator that allows to decide a further tracer to use,
+--   based on the message being processed.
+fanning
+  :: forall m a
+  . (a -> Tracer m a) -> Tracer m a
+fanning fan = Tracer $ \x -> traceWith (fan x) x
+
+newtype Counting a = Counting Int
+
+-- | A stateful tracer transformer that substitutes messages with
+--   a monotonically incrementing occurence count.
+counting
+  :: forall m a . (MonadIO m)
+  => Tracer m (Counting a) -> m (Tracer m a)
+counting tr =
+  mkTracer <$> liftIO (newIORef 0)
+ where
+    mkTracer :: IORef Int -> Tracer m a
+    mkTracer ctrref = Tracer $ \_ -> do
+      ctr <- liftIO $ atomicModifyIORef' ctrref $ \n -> join (,) (n + 1)
+      traceWith tr (Counting ctr)
+
+newtype Folding a f = Folding f
+
+-- | A generalised trace transformer that provides evolving state,
+--   defined as a strict left fold.
+folding
+  :: forall m f a
+  .  (MonadIO m)
+  => (f -> a -> f) -> f -> Tracer m (Folding a f) -> m (Tracer m a)
+folding cata initial tr =
+  mkTracer <$> liftIO (newIORef initial)
+ where
+    mkTracer :: IORef f -> Tracer m a
+    mkTracer ref = Tracer $ \a -> do
+      x' <- liftIO $ atomicModifyIORef' ref $ \x -> join (,) (cata x a)
+      traceWith tr (Folding x')

--- a/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
+++ b/tracer-transformers/src/Control/Tracer/Transformers/Synopsizer.lhs
@@ -7,8 +7,6 @@ Module: Synopsizer
 
 Synopsize runs of repeated events, as an initial message with a summary at the end.
 -}
-{-# LANGUAGE BangPatterns   #-}
-{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf     #-}
 {-# LANGUAGE RankNTypes     #-}
@@ -50,6 +48,7 @@ data Synopsized a
     }
     -- ^ Synopsis for a specified number of messages similar to the first one.
 
+
 -- | Generic Tracer transformer, intended for suppression of repeated messages.
 --
 --   The transformer is specified in terms of an internal counter (starting at zero),
@@ -80,17 +79,17 @@ mkSynopsizer resetTest tr =
 
         (Just fir, Just las) ->
           if | (ssRepeats ss, fir) `resetTest` a
-             -> (,)
-               (ss { ssRepeats = 0, ssFirst = Just a, ssLast = Just a })
-               (if ssRepeats ss == 0
-                then traceWith tr (One a)
-                else traceWith tr (Many (ssRepeats ss) fir las) >>
-                     traceWith tr (One a))
+              -> (,)
+                (ss { ssRepeats = 0, ssFirst = Just a, ssLast = Just a })
+                (if ssRepeats ss == 0
+                 then traceWith tr (One a)
+                 else traceWith tr (Many (ssRepeats ss) fir las) >>
+                      traceWith tr (One a))
 
              | otherwise
-             -> (,)
-               (ss { ssRepeats = ssRepeats ss + 1, ssLast = Just a })
-               (pure ())
+              -> (,)
+                (ss { ssRepeats = ssRepeats ss + 1, ssLast = Just a })
+                (pure ())
 
         _ -> error "Nothing is impossible at this point."
 

--- a/tracer-transformers/tracer-transformers.cabal
+++ b/tracer-transformers/tracer-transformers.cabal
@@ -15,7 +15,8 @@ build-type:          Simple
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Control.Tracer.Transformers.ObserveOutcome
+  exposed-modules:     Control.Tracer.Transformers
+                       Control.Tracer.Transformers.ObserveOutcome
                        Control.Tracer.Transformers.Synopsizer
                        Control.Tracer.Transformers.WithThreadAndTime
 


### PR DESCRIPTION
Issues: #482, https://github.com/input-output-hk/cardano-node/issues/414

This:

- adds fanning/folding/counting transformers: https://github.com/input-output-hk/iohk-monitoring-framework/pull/483/commits/ede336ca5ad8910799618f98f9817ab822a10f7b
- adds `Transformable`/`Define{Severity,PrivacyAnnotation}` instances for `Synopsizer`
- appeases `hlint` in some files
- adds `tracer-transformers` to the shell, its deps to `stack.yaml` & regens Nix

Due to the `hlint` appeasing I suggest this is reviewed on per-commit basis -- and the two listed commits are the key here -- the rest are just helpful noise..

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
