### PR TITLE
CAD-313 [#482] flexify synopsizer

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -351,7 +351,7 @@ msgThr trace = do
       resetTest :: Eq a => (Int, LogObject a) -> LogObject a -> Bool
       resetTest (counter, prevLo) thisLo =
         counter == 2 || not (prevLo `loContentEq` thisLo)
-  synopsized <- mkSynopsizer resetTest (liftSynopsized trace')
+  synopsized <- mkSynopsizer resetTest (liftSynopsized trace' Critical Public)
   Async.async (loop synopsized)
   where
     loop tr = do

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -249,7 +249,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      (severity lometa, text, maylo)
                                 (LogError text) ->
                                      (severity lometa, text, Nothing)
-                                (LogRepeats count _fir _las) ->
+                                (LogRepeats count) ->
                                      ( severity lometa
                                      , "Similar messages elided, " <> pack (show count) <> " total."
                                      , Nothing)

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -194,8 +194,6 @@ data LOContent a = LogMessage a
                  | LogError Text
                  | LogRepeats
                    { lrRepeats :: {-# UNPACK #-} !Int
-                   , lrFirst   :: !(LogObject a)
-                   , lrLast    :: !(LogObject a)
                    }
                  | LogValue Text Measurable
                  | LogStructured BS.ByteString
@@ -216,11 +214,9 @@ instance ToJSON a => ToJSON (LOContent a) where
     toJSON (LogError m) =
         object [ "kind" .= String "LogError"
                , "message" .= toJSON m]
-    toJSON (LogRepeats n f l) =
+    toJSON (LogRepeats n) =
         object [ "kind" .= String "LogRepeats"
-               , "elided-count" .= toJSON n
-               , "first-elided" .= toJSON f
-               , "last-elided"  .= toJSON l]
+               , "elided-count" .= toJSON n ]
     toJSON (LogValue n v) =
         object [ "kind" .= String "LogValue"
                , "name" .= toJSON n
@@ -257,8 +253,6 @@ instance (FromJSON a) => FromJSON (LOContent a) where
                         "LogError" -> LogError <$> v .: "message"
                         "LogRepeats" -> LogRepeats
                           <$> v .: "elided-count"
-                          <*> v .: "first-elided"
-                          <*> v .: "last-elided"
                         "LogValue" -> LogValue <$> v .: "name" <*> v .: "value"
                         "LogStructured" -> LogStructured
                                               . BS64.decodeLenient
@@ -388,7 +382,7 @@ mapLOContent :: (a -> b) -> LOContent a -> LOContent b
 mapLOContent f = \case
     LogMessage msg       -> LogMessage (f msg)
     LogError a           -> LogError a
-    LogRepeats n fir las -> LogRepeats n (mapLogObject f fir) (mapLogObject f las)
+    LogRepeats n         -> LogRepeats n
     LogStructured m      -> LogStructured m
     LogValue n v         -> LogValue n v
     ObserveOpen st       -> ObserveOpen st

--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -570,17 +570,17 @@ instance DefineSeverity a => DefineSeverity (Synopsized a) where
   defineSeverity (One a) = defineSeverity a
   defineSeverity (Many _ fir _) = defineSeverity fir
 
-instance (Transformable a IO a, ToObject a)
-       => Transformable a IO (Synopsized a) where
+instance (Transformable t IO a, ToObject t)
+       => Transformable t IO (Synopsized a) where
     trTransformer _ _ tr = Tracer $ \case
       One          a -> traceWith (toLogObject tr :: Tracer IO a) a
       Many n fir las -> traceRepeat tr n fir las
      where
        traceRepeat
          :: MonadIO m
-         => Tracer m (LogObject a) -> Int -> a -> a -> m ()
+         => Tracer m (LogObject b) -> Int -> a -> a -> m ()
        traceRepeat t repeats fir las = do
-         meta <- mkLOMeta (defineSeverity fir) (definePrivacyAnnotation fir)
+         meta <- undefined --mkLOMeta (defineSeverity fir) (definePrivacyAnnotation fir)
          traceWith t . LogObject ["synopsis"] meta $
            LogRepeats repeats (liftLO meta fir) (liftLO meta las)
        liftLO :: LOMeta -> a -> LogObject a

--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -573,18 +573,15 @@ instance DefineSeverity a => DefineSeverity (Synopsized a) where
 instance (Transformable t IO a, ToObject t)
        => Transformable t IO (Synopsized a) where
     trTransformer _ _ tr = Tracer $ \case
-      One          a -> traceWith (toLogObject tr :: Tracer IO a) a
-      Many n fir las -> traceRepeat tr n fir las
+      One            a -> traceWith (toLogObject tr :: Tracer IO a) a
+      Many n _fir _las -> traceRepeat tr n
      where
        traceRepeat
          :: MonadIO m
-         => Tracer m (LogObject b) -> Int -> a -> a -> m ()
-       traceRepeat t repeats fir las = do
-         meta <- undefined --mkLOMeta (defineSeverity fir) (definePrivacyAnnotation fir)
-         traceWith t . LogObject ["synopsis"] meta $
-           LogRepeats repeats (liftLO meta fir) (liftLO meta las)
-       liftLO :: LOMeta -> a -> LogObject a
-       liftLO meta = LogObject [] meta . LogMessage
+         => Tracer m (LogObject b) -> Int -> m ()
+       traceRepeat t repeats = do
+         meta <- mkLOMeta Critical Public
+         traceWith t (LogObject ["synopsis"] meta $ LogRepeats repeats)
 \end{code}
 
 \subsubsection{The properties of being annotated with severity and privacy}

--- a/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
+++ b/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
@@ -49,7 +49,7 @@ instance Arbitrary a => Arbitrary (LOContent a) where
   arbitrary = QC.oneof
     [ LogMessage <$> arbitrary
     , LogError <$> message
-    , LogRepeats <$> arbitrary <*> arbitrary <*> arbitrary
+    , LogRepeats <$> arbitrary
     , LogValue <$> message <*> arbitrary
     -- TODO:  fill this in later.
     -- , LogStructured <$> arbitrary

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -403,7 +403,7 @@ prop_synopsizer stream runLimit = runLimit > 1 QC.==> QC.monadicIO $ do
          setupTrace
            (TraceConfiguration cfg (MockSB msgs) "test-synopsizer" Neutral)
 
-    tr <- QC.run $ mkSynopsizer resetTest (liftSynopsized base)
+    tr <- QC.run $ mkSynopsizer resetTest (liftSynopsized base Critical Public)
     QC.run $ mapM_ (traceWith tr) stream
 
     -- acquire the traced objects


### PR DESCRIPTION
Issue: https://github.com/input-output-hk/iohk-monitoring-framework/issues/482

https://github.com/input-output-hk/iohk-monitoring-framework/pulls/483 turned out not to be sufficient -- the `Transformable` instance had to be made more polymorphic, at the cost of expressivity at the `LogObject` level.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
