### PR TITLE
[#486] Switch to a non-STM bounded queue

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -106,6 +106,7 @@ library
                        time-units,
                        tracer-transformers,
                        transformers,
+                       unagi-chan,
                        unordered-containers,
                        vector,
                        yaml, libyaml

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -6,6 +6,7 @@
         "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         "katip" = (((hackage.katip)."0.8.3.0").revisions).default;
+        "unagi-chan" = (((hackage.unagi-chan)."0.4.1.0").revisions).default;
         } // {
         contra-tracer = ./contra-tracer.nix;
         tracer-transformers = ./tracer-transformers.nix;

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -45,6 +45,7 @@
           (hsPkgs.time-units)
           (hsPkgs.tracer-transformers)
           (hsPkgs.transformers)
+          (hsPkgs.unagi-chan)
           (hsPkgs.unordered-containers)
           (hsPkgs.vector)
           (hsPkgs.yaml)

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,7 @@ extra-deps:
   - prometheus-2.1.2
   - libsystemd-journal-1.4.4
   - katip-0.8.3.0
+  - unagi-chan-0.4.1.0
   - git: https://github.com/CodiePP/ekg-prometheus-adapter
     commit: 1a258b6df7d9807d4c4ff3e99722223d31a2c320
 


### PR DESCRIPTION
Issue: #486 

Blocked by https://github.com/input-output-hk/iohk-monitoring-framework/issues/489

---

- [x] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
