### PR TITLE
[#486][#492] Don't link STM timeout exceptions from the switchboard's thread

### DIFF
--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -37,6 +37,7 @@ import           System.Directory (getTemporaryDirectory, removeFile)
 import           System.Mem (performMajorGC)
 import           System.FilePath ((</>))
 
+import           Cardano.BM.Backend.Switchboard (Switchboard)
 import           Cardano.BM.Configuration (Configuration, evalFilters,
                      inspectSeverity, minSeverity, setMinSeverity, setSeverity)
 import           Cardano.BM.Configuration.Model (empty, setDefaultBackends,
@@ -91,6 +92,7 @@ tests = testGroup "Testing Trace" [
 #endif
       , testCaseInfo "demonstrating logging" simpleDemo
       , testCaseInfo "demonstrating nested named context logging" exampleWithNamedContexts
+      , testCase "major GC doesn't cause an exception for lost traces" unitShutdown
       ]
 
 unit_tests :: TestTree
@@ -844,5 +846,21 @@ unitLoggingPrivate = do
   where
     message :: Text
     message = "Just a message"
+
+\end{code}
+
+\subsubsection{Verify that the shutdown-free sequence survives a major GC.}\label{code:unitShutdown}
+
+\begin{code}
+
+unitShutdown :: Assertion
+unitShutdown = do
+    _ :: (Trace IO Text, Switchboard Text)
+      <- flip Setup.setupTrace_ "" =<< empty
+
+    threadDelay 1000
+    performMajorGC
+    threadDelay 1000
+    assertBool "Win!" True
 
 \end{code}


### PR DESCRIPTION
Issues: #486 #492 

This adds:
1. a test, which fails.
2. a fix for the test -- basically ignoring the STM timeouts from the switchboard's thread

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
