### PR TITLE
CAD-371 trace acceptor plugin

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,8 @@ packages:
   plugins/backend-ekg
   plugins/backend-graylog
   plugins/backend-monitoring
+  plugins/backend-trace-acceptor
+  plugins/backend-trace-forwarder
   plugins/scribe-systemd
   examples
 

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -57,8 +57,6 @@ library
                        Cardano.BM.Backend.LogBuffer
                        Cardano.BM.Backend.ProcessQueue
                        Cardano.BM.Backend.Switchboard
-                       Cardano.BM.Backend.TraceAcceptor
-                       Cardano.BM.Backend.TraceForwarder
                        Cardano.BM.Plugin
                        Cardano.BM.Rotator
                        Cardano.BM.Setup

--- a/iohk-monitoring/src/Cardano/BM/Data/BackendKind.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/BackendKind.lhs
@@ -21,13 +21,17 @@ import           Data.Text (Text)
 %endif
 
 \subsubsection{BackendKind}\label{code:BackendKind}\index{BackendKind}
-\label{code:AggregationBK}\label{code:EditorBK}\label{code:EKGViewBK}\label{code:KatipBK}
-\label{code:LogBufferBK}\label{code:MonitoringBK}\label{code:TraceAcceptorBK}
-\label{code:SwitchboardBK}\label{code:GraylogBK}\label{code:TraceForwarderBK}\label{code:UserDefinedBK}
-\index{BackendKind!AggregationBK}\index{BackendKind!EKGViewBK}\index{BackendKind!KatipBK}
-\index{BackendKind!LogBufferBK}\index{BackendKind!MonitoringBK}\index{BackendKind!EditorBK}
-\index{BackendKind!TraceAcceptorBK}\index{BackendKind!TraceForwarderBK}
-\index{BackendKind!SwitchboardBK}\index{BackendKind!GraylogBK}\index{BackendKind!UserDefinedBK}
+\label{code:AggregationBK}\index{BackendKind!AggregationBK}
+\label{code:EditorBK}\index{BackendKind!EditorBK}
+\label{code:EKGViewBK}\index{BackendKind!EKGViewBK}
+\label{code:GraylogBK}\index{BackendKind!GraylogBK}
+\label{code:KatipBK}\index{BackendKind!KatipBK}
+\label{code:LogBufferBK}\index{BackendKind!LogBufferBK}
+\label{code:MonitoringBK}\index{BackendKind!MonitoringBK}
+\label{code:SwitchboardBK}\index{BackendKind!SwitchboardBK}
+\label{code:TraceAcceptorBK}\index{BackendKind!TraceAcceptorBK}
+\label{code:TraceForwarderBK}\index{BackendKind!TraceForwarderBK}
+\label{code:UserDefinedBK}\index{BackendKind!UserDefinedBK}
 This identifies the backends that can be attached to the |Switchboard|.
 \begin{code}
 
@@ -39,7 +43,7 @@ data BackendKind =
     | KatipBK
     | LogBufferBK
     | MonitoringBK
-    | TraceAcceptorBK FilePath
+    | TraceAcceptorBK
     | TraceForwarderBK
     | UserDefinedBK Text
     | SwitchboardBK
@@ -54,9 +58,7 @@ instance ToJSON BackendKind where
     toJSON LogBufferBK            = String "LogBufferBK"
     toJSON MonitoringBK           = String "MonitoringBK"
     toJSON TraceForwarderBK       = String "TraceForwarderBK"
-    toJSON (TraceAcceptorBK file) = object [ "kind" .= String "TraceAcceptorBK"
-                                           , "path" .= toJSON file
-                                           ]
+    toJSON TraceAcceptorBK        = String "TraceAcceptorBK"
     toJSON (UserDefinedBK name)   = object [ "kind" .= String "UserDefinedBK"
                                            , "name" .= toJSON name
                                            ]
@@ -70,8 +72,6 @@ instance FromJSON BackendKind where
                                 case c of
                                     "UserDefinedBK"   ->
                                         UserDefinedBK <$> value .: "name"
-                                    "TraceAcceptorBK" ->
-                                        TraceAcceptorBK <$> value .: "path"
                                     _                 -> fail "not expected kind"
                     )
                     v
@@ -85,6 +85,7 @@ instance FromJSON BackendKind where
                         "KatipBK"          -> pure KatipBK
                         "LogBufferBK"      -> pure LogBufferBK
                         "MonitoringBK"     -> pure MonitoringBK
+                        "TraceAcceptorBK"  -> pure TraceAcceptorBK
                         "TraceForwarderBK" -> pure TraceForwarderBK
                         "SwitchboardBK"    -> pure SwitchboardBK
                         _                  -> fail "not expected BackendKind"

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -162,8 +162,6 @@ unitConfigurationParsedRepresentation = do
             , "- AggregationBK"
             , "- EKGViewBK"
             , "- KatipBK"
-            , "- path: log-pipe"
-            , "  kind: TraceAcceptorBK"
             , "hasPrometheus: null"
             , "hasGraylog: 12788"
             , "hasGUI: null"
@@ -310,7 +308,6 @@ unitConfigurationParsed = do
         , cgSetupBackends     = [ AggregationBK
                                 , EKGViewBK
                                 , KatipBK
-                                , TraceAcceptorBK "log-pipe"
                                 ]
         , cgMapScribe         = HM.fromList [ ("iohk.interesting.value",
                                                     ["StdoutSK::stdout","FileSK::testlog"])

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -14,8 +14,6 @@ setupBackends:
   - AggregationBK
   - EKGViewBK
   - KatipBK
-  - kind: TraceAcceptorBK
-    path: log-pipe
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -15,6 +15,8 @@
         lobemo-backend-ekg = ./lobemo-backend-ekg.nix;
         lobemo-backend-graylog = ./lobemo-backend-graylog.nix;
         lobemo-backend-monitoring = ./lobemo-backend-monitoring.nix;
+        lobemo-backend-trace-acceptor = ./lobemo-backend-trace-acceptor.nix;
+        lobemo-backend-trace-forwarder = ./lobemo-backend-trace-forwarder.nix;
         lobemo-scribe-systemd = ./lobemo-scribe-systemd.nix;
         lobemo-examples = ./lobemo-examples.nix;
         ekg-prometheus-adapter = ./ekg-prometheus-adapter.nix;

--- a/nix/.stack.nix/lobemo-backend-trace-acceptor.nix
+++ b/nix/.stack.nix/lobemo-backend-trace-acceptor.nix
@@ -1,0 +1,38 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = {
+        name = "lobemo-backend-trace-acceptor";
+        version = "0.1.0.0";
+        };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
+      url = "";
+      synopsis = "a trace acceptor backend";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.iohk-monitoring)
+          (hsPkgs.aeson)
+          (hsPkgs.async)
+          (hsPkgs.bytestring)
+          (hsPkgs.network)
+          (hsPkgs.safe-exceptions)
+          (hsPkgs.stm)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          ];
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ../.././plugins/backend-trace-acceptor;
+    }

--- a/nix/.stack.nix/lobemo-backend-trace-forwarder.nix
+++ b/nix/.stack.nix/lobemo-backend-trace-forwarder.nix
@@ -1,0 +1,38 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.0";
+      identifier = {
+        name = "lobemo-backend-trace-forwarder";
+        version = "0.1.0.0";
+        };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
+      url = "";
+      synopsis = "this backend forwards log items to a trace acceptor";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.iohk-monitoring)
+          (hsPkgs.aeson)
+          (hsPkgs.async)
+          (hsPkgs.bytestring)
+          (hsPkgs.network)
+          (hsPkgs.safe-exceptions)
+          (hsPkgs.stm)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          ];
+        };
+      };
+    } // rec {
+    src = (pkgs.lib).mkDefault ../.././plugins/backend-trace-forwarder;
+    }

--- a/plugins/backend-aggregation/src/Cardano/BM/Backend/Aggregation.lhs
+++ b/plugins/backend-aggregation/src/Cardano/BM/Backend/Aggregation.lhs
@@ -15,16 +15,13 @@
 module Cardano.BM.Backend.Aggregation
     (
       Aggregation
-    , effectuate
-    , realizefrom
-    , unrealize
     -- * Plugin
     , plugin
     ) where
 
 import qualified Control.Concurrent.Async as Async
-import           Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar,
-                     modifyMVar_, putMVar, readMVar, tryTakeMVar, withMVar)
+import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar,
+                     readMVar, tryTakeMVar, withMVar)
 import           Control.Concurrent.STM (atomically)
 import qualified Control.Concurrent.STM.TBQueue as TBQ
 import           Control.Exception.Safe (throwM)
@@ -34,17 +31,14 @@ import           Data.Aeson (FromJSON, ToJSON)
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text, pack)
 import qualified Data.Text.IO as TIO
-import           Data.Time.Clock (getCurrentTime)
 import           Data.Word (Word64)
 import           GHC.Clock (getMonotonicTimeNSec)
 import           System.IO (stderr)
 
 import           Cardano.BM.Backend.ProcessQueue (processQueue)
 import           Cardano.BM.Configuration.Model (Configuration, getAggregatedKind)
-import           Cardano.BM.Data.Aggregated (Aggregated (..), BaseStats (..),
-                     EWMA (..), Measurable (..), Stats (..), ewma, getDouble,
-                     getInteger, singletonStats, subtractMeasurable,
-                     updateAggregation)
+import           Cardano.BM.Data.Aggregated (Aggregated (..), EWMA (..),
+                     Measurable (..), ewma, singletonStats, updateAggregation)
 import           Cardano.BM.Data.AggregatedKind (AggregatedKind (..))
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.Counter (Counter (..), CounterState (..),

--- a/plugins/backend-editor/src/Cardano/BM/Backend/Editor.lhs
+++ b/plugins/backend-editor/src/Cardano/BM/Backend/Editor.lhs
@@ -12,9 +12,6 @@
 module Cardano.BM.Backend.Editor
     (
       Editor
-    , effectuate
-    , realizefrom
-    , unrealize
     -- * Plugin
     , plugin
     ) where
@@ -145,7 +142,7 @@ instance (ToJSON a, FromJSON a) => IsBackend Editor a where
          meta <- mkLOMeta Error Public
          traceWith trace $ LogObject ["#editor", "realizeFrom"] meta $
            LogError $ "Editor backend disabled due to initialisation error: " <> (pack $ show e)
-         swapMVar mvar nullEditor
+         _ <- swapMVar mvar nullEditor
          pure ()
 
     unrealize editor =

--- a/plugins/backend-graylog/src/Cardano/BM/Backend/Graylog.lhs
+++ b/plugins/backend-graylog/src/Cardano/BM/Backend/Graylog.lhs
@@ -13,17 +13,14 @@
 module Cardano.BM.Backend.Graylog
     (
       Graylog
-    , effectuate
-    , realizefrom
-    , unrealize
     -- * Plugin
     , plugin
     ) where
 
 import           Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.Async as Async
-import           Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar,
-                     putMVar, readMVar, withMVar, modifyMVar_, tryTakeMVar)
+import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar,
+                     readMVar, withMVar, tryTakeMVar)
 import           Control.Concurrent.STM (atomically)
 import qualified Control.Concurrent.STM.TBQueue as TBQ
 import           Control.Exception.Safe (SomeException, catch, throwM)
@@ -33,7 +30,6 @@ import           Data.Aeson (FromJSON, ToJSON (..), Value, encode, object, (.=))
 import qualified Data.ByteString.Lazy.Char8 as BS8
 import           Data.Text (Text, pack)
 import qualified Data.Text.IO as TIO
-import           Data.Time (getCurrentTime)
 import qualified Network.Socket as Net
 import           Network.Socket.ByteString (sendAll)
 import           System.IO (stderr)
@@ -91,8 +87,8 @@ instance IsEffectuator Graylog a where
             (LogObject logname lometa (AggregatedMessage ags)) -> liftIO $ do
                 let traceAgg :: [(Text,Aggregated)] -> IO ()
                     traceAgg [] = return ()
-                    traceAgg ((n,AggregatedEWMA ewma):r) = do
-                        enqueue $ LogObject (logname <> [n]) lometa (LogValue "avg" $ avg ewma)
+                    traceAgg ((n,AggregatedEWMA agewma):r) = do
+                        enqueue $ LogObject (logname <> [n]) lometa (LogValue "avg" $ avg agewma)
                         traceAgg r
                     traceAgg ((n,AggregatedStats stats):r) = do
                         let statsname = logname <> [n]

--- a/plugins/backend-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
+++ b/plugins/backend-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
@@ -17,16 +17,13 @@
 module Cardano.BM.Backend.Monitoring
     (
       Monitor
-    , effectuate
-    , realizefrom
-    , unrealize
     -- * Plugin
     , plugin
     ) where
 
 import qualified Control.Concurrent.Async as Async
-import           Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar,
-                     modifyMVar_, readMVar, tryReadMVar, tryTakeMVar, withMVar)
+import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar,
+                     readMVar, tryReadMVar, tryTakeMVar, withMVar)
 import           Control.Concurrent.STM (atomically)
 import qualified Control.Concurrent.STM.TBQueue as TBQ
 import           Control.Exception.Safe (throwM)
@@ -36,9 +33,8 @@ import qualified Data.HashMap.Strict as HM
 import           Data.Maybe (catMaybes)
 import           Data.Text (Text, pack)
 import qualified Data.Text.IO as TIO
-import           Data.Time.Clock (getCurrentTime)
 import           GHC.Clock (getMonotonicTimeNSec)
-import           System.IO (stderr, stdout)
+import           System.IO (stderr)
 
 import           Cardano.BM.Backend.LogBuffer
 import           Cardano.BM.Backend.ProcessQueue (processQueue)
@@ -49,7 +45,6 @@ import           Cardano.BM.Data.Counter (Counter (..), CounterState (..),
                      nameCounter)
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MonitoringEval
-import           Cardano.BM.Data.Severity (Severity (..))
 import           Cardano.BM.Plugin (Plugin (..))
 import qualified Cardano.BM.Trace as Trace
 

--- a/plugins/backend-trace-acceptor/LICENSE
+++ b/plugins/backend-trace-acceptor/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/backend-trace-acceptor/NOTICE
+++ b/plugins/backend-trace-acceptor/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2019 IOHK
+
+Licensed under the Apache License, Version 2.0 (the "License”). You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/plugins/backend-trace-acceptor/README.md
+++ b/plugins/backend-trace-acceptor/README.md
@@ -1,0 +1,4 @@
+# trace acceptor
+
+reads log items from a UNIX pipe and forwards them to the Switchboard. Use 'trace-forwarder' to write log items to the pipe.
+

--- a/plugins/backend-trace-acceptor/Setup.hs
+++ b/plugins/backend-trace-acceptor/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/plugins/backend-trace-acceptor/lobemo-backend-trace-acceptor.cabal
+++ b/plugins/backend-trace-acceptor/lobemo-backend-trace-acceptor.cabal
@@ -1,0 +1,33 @@
+cabal-version:       2.0
+name:                lobemo-backend-trace-acceptor
+version:             0.1.0.0
+synopsis:            a trace acceptor backend
+-- description:
+homepage:            https://github.com/input-output-hk/iohk-monitoring-framework
+-- bug-reports:
+license:             Apache-2.0
+license-files:       LICENSE, NOTICE
+author:              Alexander Diemand
+maintainer:          operations@iohk.io
+copyright:           2020 IOHK
+category:            Benchmarking
+build-type:          Simple
+extra-source-files:  README.md
+
+library
+  exposed-modules:     Cardano.BM.Backend.TraceAcceptor
+  -- other-modules:
+  -- other-extensions:
+  default-extensions:  OverloadedStrings
+  build-depends:       base >=4.11,
+                       iohk-monitoring,
+                       aeson,
+                       async,
+                       bytestring,
+                       network,
+                       safe-exceptions,
+                       stm,
+                       text,
+                       time
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/plugins/backend-trace-forwarder/LICENSE
+++ b/plugins/backend-trace-forwarder/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/backend-trace-forwarder/NOTICE
+++ b/plugins/backend-trace-forwarder/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2019 IOHK
+
+Licensed under the Apache License, Version 2.0 (the "License”). You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/plugins/backend-trace-forwarder/README.md
+++ b/plugins/backend-trace-forwarder/README.md
@@ -1,0 +1,3 @@
+# trace forwarder
+
+writes log items to a UNIX pipe.

--- a/plugins/backend-trace-forwarder/Setup.hs
+++ b/plugins/backend-trace-forwarder/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/plugins/backend-trace-forwarder/lobemo-backend-trace-forwarder.cabal
+++ b/plugins/backend-trace-forwarder/lobemo-backend-trace-forwarder.cabal
@@ -1,0 +1,33 @@
+cabal-version:       2.0
+name:                lobemo-backend-trace-forwarder
+version:             0.1.0.0
+synopsis:            this backend forwards log items to a trace acceptor
+-- description:
+homepage:            https://github.com/input-output-hk/iohk-monitoring-framework
+-- bug-reports:
+license:             Apache-2.0
+license-files:       LICENSE, NOTICE
+author:              Alexander Diemand
+maintainer:          operations@iohk.io
+copyright:           2020 IOHK
+category:            Benchmarking
+build-type:          Simple
+extra-source-files:  README.md
+
+library
+  exposed-modules:     Cardano.BM.Backend.TraceForwarder
+  -- other-modules:
+  -- other-extensions:
+  default-extensions:  OverloadedStrings
+  build-depends:       base >=4.11,
+                       iohk-monitoring,
+                       aeson,
+                       async,
+                       bytestring,
+                       network,
+                       safe-exceptions,
+                       stm,
+                       text,
+                       time
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/plugins/scribe-systemd/src/Cardano/BM/Scribe/Systemd.lhs
+++ b/plugins/scribe-systemd/src/Cardano/BM/Scribe/Systemd.lhs
@@ -36,13 +36,10 @@ import           System.Posix.Syslog (Facility)
 import qualified Katip as K
 import qualified Katip.Core as KC
 import           Katip.Format.Time (formatAsIso8601)
-import           Katip.Scribes.Handle (brackets)
 
 import           Cardano.BM.Configuration
 import           Cardano.BM.Backend.Log (sev2klog)
 import           Cardano.BM.Data.Backend
-import           Cardano.BM.Data.LogItem
-import           Cardano.BM.Data.Output (ScribeId)
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.Trace
 import           Cardano.BM.Plugin (Plugin (..))
@@ -59,7 +56,7 @@ to systemd's journal on \emph{Linux}.
 #ifdef LINUX
 plugin :: (IsEffectuator s a, ToJSON a, FromJSON a)
        => Configuration -> Trace IO a -> s a -> IO (Plugin a)
-plugin config trace sb =
+plugin _ _ _ =
     ScribePlugin
                <$> mkJournalScribe
                <*> pure "JournalSK"

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,8 @@ packages:
   - plugins/backend-ekg
   - plugins/backend-graylog
   - plugins/backend-monitoring
+  - plugins/backend-trace-acceptor
+  - plugins/backend-trace-forwarder
   - plugins/scribe-systemd
   - examples
 


### PR DESCRIPTION

description
-----------

- [x] trace forwarder and acceptor only work on UNIX (atm), so they should not be included in the base framework. These are now backend plugins that can be loaded explicitly at startup.


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
