### PR TITLE
CAD-406 fixed space leak in LogBuffer

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/LogBuffer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/LogBuffer.lhs
@@ -3,6 +3,7 @@
 
 %if style == newcode
 \begin{code}
+{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -15,7 +16,8 @@ module Cardano.BM.Backend.LogBuffer
     , unrealize
     ) where
 
-import           Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, withMVar)
+import           Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_,
+                     newMVar)
 import           Data.Aeson (FromJSON)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text.IO as TIO
@@ -37,7 +39,7 @@ newtype LogBuffer a = LogBuffer
 type LogBufferMVar a = MVar (LogBufferInternal a)
 
 data LogBufferInternal a = LogBufferInternal
-    { logBuffer :: LogBufferMap a
+    { logBuffer :: !(LogBufferMap a)
     }
 
 \end{code}
@@ -50,11 +52,14 @@ type LogBufferMap a = HM.HashMap LoggerName (LogObject a)
 \end{code}
 
 \subsubsection{Read out the latest |LogObject|s}
+Returns a list of the maps keys and values.
+And, resets the map.
 \begin{code}
 readBuffer :: LogBuffer a -> IO [(LoggerName, LogObject a)]
 readBuffer buffer =
-    withMVar (getLogBuf buffer) $ \currentBuffer ->
-        return $ HM.toList $ logBuffer currentBuffer
+    modifyMVar (getLogBuf buffer) $ \currentBuffer -> do
+        let !l = HM.toList $ logBuffer currentBuffer
+        return (LogBufferInternal HM.empty, l)
 
 \end{code}
 
@@ -62,12 +67,12 @@ readBuffer buffer =
 Function |effectuate| is called to pass in a |LogObject| for log buffering.
 \begin{code}
 instance IsEffectuator LogBuffer a where
-    effectuate buffer lo@(LogObject loname _lometa (LogValue lvname _lvalue)) = do
+    effectuate buffer lo@(LogObject loname _lometa (LogValue lvname _lvalue)) =
         modifyMVar_ (getLogBuf buffer) $ \currentBuffer ->
-            return $ LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname <> "." <> lvname) lo $ logBuffer currentBuffer
-    effectuate buffer lo@(LogObject loname _lometa _logitem) = do
+            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname <> "." <> lvname) lo $ logBuffer currentBuffer
+    effectuate buffer lo@(LogObject loname _lometa _logitem) =
         modifyMVar_ (getLogBuf buffer) $ \currentBuffer ->
-            return $ LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname) lo $ logBuffer currentBuffer
+            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname) lo $ logBuffer currentBuffer
 
     handleOverflow _ = TIO.hPutStrLn stderr "Notice: overflow in LogBuffer, dropping log items!"
 
@@ -80,8 +85,9 @@ instance IsEffectuator LogBuffer a where
 instance FromJSON a => IsBackend LogBuffer a where
     bekind _ = LogBufferBK
 
-    realize _ = do
+    realize _ =
         let emptyBuffer = LogBufferInternal HM.empty
+        in
         LogBuffer <$> newMVar emptyBuffer
 
     unrealize _ = return ()

--- a/iohk-monitoring/src/Cardano/BM/Data/Aggregated.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Aggregated.lhs
@@ -304,9 +304,9 @@ S_t =
 \end{cases}
 $$
 \begin{code}
-data EWMA = EmptyEWMA { alpha :: Double }
-          | EWMA { alpha :: Double
-                 , avg   :: Measurable
+data EWMA = EmptyEWMA { alpha :: !Double }
+          | EWMA { alpha :: !Double
+                 , avg   :: !Measurable
                  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Data/Counter.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Counter.lhs
@@ -69,7 +69,7 @@ nameCounter (Counter RTSStats           _ _) = "RTS"
 \subsubsection{CounterState}\label{code:CounterState}\index{CounterState}
 \begin{code}
 data CounterState = CounterState {
-      csCounters   :: ![Counter]
+      csCounters   :: [Counter]
     }
     deriving (Show, Eq, Generic, ToJSON, FromJSON)
 

--- a/iohk-monitoring/src/Cardano/BM/Data/Counter.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Counter.lhs
@@ -34,9 +34,9 @@ import           Cardano.BM.Data.Aggregated (Measurable (..))
 \subsubsection{Counter}\label{code:Counter}\index{Counter}\label{code:CounterType}\index{CounterType}
 \begin{code}
 data Counter = Counter
-               { cType  :: CounterType
-               , cName  :: Text
-               , cValue :: Measurable
+               { cType  :: !CounterType
+               , cName  :: !Text
+               , cValue :: !Measurable
                }
                deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
@@ -69,7 +69,7 @@ nameCounter (Counter RTSStats           _ _) = "RTS"
 \subsubsection{CounterState}\label{code:CounterState}\index{CounterState}
 \begin{code}
 data CounterState = CounterState {
-      csCounters   :: [Counter]
+      csCounters   :: ![Counter]
     }
     deriving (Show, Eq, Generic, ToJSON, FromJSON)
 


### PR DESCRIPTION
description
-----------

- [x] there was a space leak in `LogBuffer`; this fix was possible with great input from @ksaric 

### testing

1.) compile using `stack --nix --profile`
2.) run using `stack --nix --profile exec example-complex -- +RTS -hc -L45 -RTS`
3.) analyse: `hp2ps -c example-complex.hp`

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
