### PR TITLE
CAD-403:  add a test for `defaultConfigStdout` roundtrip & fix it

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -518,10 +518,7 @@ setupFromRepresentation r = do
     r_hasGraylog repr = case (R.hasGraylog repr) of
                        Nothing -> 0
                        Just p  -> p
-    r_hasPrometheus repr = Just $ fromMaybe
-                           ( "127.0.0.1"
-                           , 12799) -- default port for Prometheus
-                           (R.hasPrometheus repr)
+    r_hasPrometheus repr = R.hasPrometheus repr
     r_hasGUI repr = case (R.hasGUI repr) of
                        Nothing -> 0
                        Just p  -> p
@@ -545,13 +542,7 @@ empty = do
                            { cgMinSeverity       = Debug
                            , cgDefRotation       = Nothing
                            , cgMapSeverity       = HM.empty
-                           , cgMapSubtrace       = HM.fromList [
-                                                     ("#messagecounters.ekgview", NoTrace),
-                                                     ("#messagecounters.aggregation", NoTrace),
-                                                     ("#messagecounters.switchboard", NoTrace),
-                                                     ("#messagecounters.monitoring", NoTrace),
-                                                     ("#messagecounters.katip", NoTrace),
-                                                     ("#messagecounters.graylog", NoTrace) ]
+                           , cgMapSubtrace       = HM.empty
                            , cgOptions           = HM.empty
                            , cgMapBackend        = HM.empty
                            , cgDefBackendKs      = []

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -64,7 +64,8 @@ unitTests = testGroup "Unit tests" [
         testCase "static representation" unitConfigurationStaticRepresentation
       , testCase "parsed representation" unitConfigurationParsedRepresentation
       , testCase "parsed configuration" unitConfigurationParsed
-      , testCase "export configuration" unitConfigurationExport
+      , testCase "export configuration: from file" unitConfigurationExport
+      , testCase "export configuration: defaultConfigStdout" unitConfigurationExportStdout
       , testCase "check scribe caching" unitConfigurationCheckScribeCache
       , testCase "test ops on Configuration" unitConfigurationOps
     ]
@@ -377,6 +378,40 @@ unitConfigurationExport = do
     cfgInternal  <- readMVar $ getCG cfg
     cfgInternal' <- readMVar $ getCG cfg'
 
+    cfgInternal' @?= cfgInternal
+
+unitConfigurationExportStdout :: Assertion
+unitConfigurationExportStdout = do
+    cfg <- defaultConfigStdout
+
+    cfg' <- withSystemTempFile "config.yaml-1213" $ \file0 _ -> do
+                let file = file0 <> "-copy"
+                exportConfiguration cfg file
+                setup file
+
+    cfgInternal  <- readMVar $ getCG cfg
+    cfgInternal' <- readMVar $ getCG cfg'
+
+    cgMinSeverity        cfgInternal' @?= cgMinSeverity        cfgInternal
+    cgDefRotation        cfgInternal' @?= cgDefRotation        cfgInternal
+    cgMapSeverity        cfgInternal' @?= cgMapSeverity        cfgInternal
+    cgMapSubtrace        cfgInternal' @?= cgMapSubtrace        cfgInternal
+    cgOptions            cfgInternal' @?= cgOptions            cfgInternal
+    cgMapBackend         cfgInternal' @?= cgMapBackend         cfgInternal
+    cgDefBackendKs       cfgInternal' @?= cgDefBackendKs       cfgInternal
+    cgSetupBackends      cfgInternal' @?= cgSetupBackends      cfgInternal
+    cgMapScribe          cfgInternal' @?= cgMapScribe          cfgInternal
+    cgMapScribeCache     cfgInternal' @?= cgMapScribeCache     cfgInternal
+    cgDefScribes         cfgInternal' @?= cgDefScribes         cfgInternal
+    cgSetupScribes       cfgInternal' @?= cgSetupScribes       cfgInternal
+    cgMapAggregatedKind  cfgInternal' @?= cgMapAggregatedKind  cfgInternal
+    cgDefAggregatedKind  cfgInternal' @?= cgDefAggregatedKind  cfgInternal
+    cgMonitors           cfgInternal' @?= cgMonitors           cfgInternal
+    cgPortEKG            cfgInternal' @?= cgPortEKG            cfgInternal
+    cgPortGraylog        cfgInternal' @?= cgPortGraylog        cfgInternal
+    cgBindAddrPrometheus cfgInternal' @?= cgBindAddrPrometheus cfgInternal
+    cgPortGUI            cfgInternal' @?= cgPortGUI            cfgInternal
+    cgLogOutput          cfgInternal' @?= cgLogOutput          cfgInternal
     cfgInternal' @?= cfgInternal
 
 \end{code}

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -361,7 +361,7 @@ unitConfigurationParsed = do
                                             ]
         , cgPortEKG           = 12789
         , cgPortGraylog       = 12788
-        , cgBindAddrPrometheus = Just ("127.0.0.1", 12799) -- the default value
+        , cgBindAddrPrometheus = Nothing
         , cgPortGUI           = 0
         , cgLogOutput         = Nothing
         }


### PR DESCRIPTION
checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
