### PR TITLE
CAD-425:  make JournalSK a valid ScribeKind

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
@@ -43,7 +43,7 @@ This identifies katip's scribes by type.
 data ScribeKind = FileSK
                 | StdoutSK
                 | StderrSK
-                -- | JournalSK
+                | JournalSK
                 | DevNullSK
                 | UserDefinedSK
                 deriving (Generic, Eq, Ord, Show, Read, FromJSON, ToJSON)


### PR DESCRIPTION
This is necessary for proper use of the journald scribe -- allows `JournalSK` to be used as a value in the `defaultScribes` configuration option.

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
