### PR TITLE
CAD-425 journald scribe

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -405,6 +405,7 @@ main = do
     Cardano.BM.Backend.Monitoring.plugin c tr sb
       >>= loadPlugin sb
 #ifdef LINUX
+    -- inspect logs with 'journalctl -t example-complex'
     Cardano.BM.Scribe.Systemd.plugin c tr sb "example-complex"
       >>= loadPlugin sb
 #endif

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -49,6 +49,7 @@ executable example-complex
                        lobemo-backend-editor,
                        lobemo-backend-ekg,
                        lobemo-backend-monitoring,
+                       lobemo-scribe-systemd,
                        async,
                        bytestring,
                        mtl,

--- a/examples/simple/Main.lhs
+++ b/examples/simple/Main.lhs
@@ -79,7 +79,7 @@ main = do
                             , scRotation = Nothing
                             }
                          ]
-    CM.setScribes c "simple.systemd" (Just ["JournalSK"])
+    CM.setScribes c "simple.systemd" (Just ["JournalSK::cardano"])
 #endif
     CM.setScribes c "simple.json" (Just ["StdoutSK::json"])
     (tr :: Trace IO String, sb) <- setupTrace_ c "simple"
@@ -87,6 +87,7 @@ main = do
     let mybe = MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be }
     addUserDefinedBackend sb mybe "MyBackend"
 #ifdef LINUX
+    -- inspect log with 'journalctl -t cardano'
     Cardano.BM.Scribe.Systemd.plugin c tr sb "cardano"
       >>= loadPlugin sb
 #endif

--- a/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
@@ -43,7 +43,7 @@ This identifies katip's scribes by type.
 data ScribeKind = FileSK
                 | StdoutSK
                 | StderrSK
-                -- | JournalSK
+                | JournalSK
                 | DevNullSK
                 | UserDefinedSK
                 deriving (Generic, Eq, Ord, Show, Read, FromJSON, ToJSON)

--- a/nix/.stack.nix/lobemo-examples.nix
+++ b/nix/.stack.nix/lobemo-examples.nix
@@ -39,6 +39,7 @@
             (hsPkgs.lobemo-backend-editor)
             (hsPkgs.lobemo-backend-ekg)
             (hsPkgs.lobemo-backend-monitoring)
+            (hsPkgs.lobemo-scribe-systemd)
             (hsPkgs.async)
             (hsPkgs.bytestring)
             (hsPkgs.mtl)

--- a/plugins/scribe-systemd/src/Cardano/BM/Scribe/Systemd.lhs
+++ b/plugins/scribe-systemd/src/Cardano/BM/Scribe/Systemd.lhs
@@ -59,7 +59,7 @@ plugin :: (IsEffectuator s a, ToJSON a, FromJSON a)
 plugin _ _ _ syslogIdent =
     ScribePlugin
                <$> mkJournalScribe syslogIdent
-               <*> pure "JournalSK"
+               <*> pure ("JournalSK::" <> syslogIdent)
 #endif
 
 \end{code}


### PR DESCRIPTION

description
-----------

- [x] reenabled JournalSK (by Serge); added syslog identifier to scribe name and verified in examples


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [x] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [x] add milestone (the same as the linked issue)
