### PR TITLE
CAD-456:  expose structure in Katip logging

### DIFF
--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -43,7 +43,8 @@ executable example-complex
   default-extensions:  OverloadedStrings
   ghc-options:         -threaded -Wall -O2 -rtsopts "-with-rtsopts=-T"
   other-modules:
-  build-depends:       base,
+  build-depends:       aeson,
+                       base,
                        iohk-monitoring,
                        lobemo-backend-aggregation,
                        lobemo-backend-editor,

--- a/nix/.stack.nix/lobemo-examples.nix
+++ b/nix/.stack.nix/lobemo-examples.nix
@@ -33,6 +33,7 @@
           };
         "example-complex" = {
           depends = ([
+            (hsPkgs.aeson)
             (hsPkgs.base)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.lobemo-backend-aggregation)


### PR DESCRIPTION
1. make structured log messages come through the Katip messages unmolested, instead of serialising as `Text`
1. extend `example-complex` with a sample of structured logging
1. resolve warnings & hlints

Observable via `example-complex`'s stdout change (when it's reconfigured as `ScJson` & augmented with a `traceWith (toLogObject' StructuredLogging MaximalVerbosity tr) (Pet "bella" 8)`):

before:
`{"at":"2020-01-31T19:54:33.74Z","env":"<unknown>:0.1.10.1","ns":["complex","message"],"data":{},"app":[],"msg":"{\"kind\":\"Pet\",\"age\":8,\"name\":\"bella\"}","pid":"14239","loc":null,"host":"","sev":"Critical","thread":"39"}`

after:
`{"at":"2020-01-31T21:11:50.57Z","env":"<unknown>:0.1.10.1","ns":["complex","message"],"data":{"kind":"Pet","age":8,"name":"bella"},"app":[],"msg":"","pid":"11665","loc":null,"host":"","sev":"Critical","thread":"39"}`

# TODO

- [ ] decide if we want to avoid the unnecessary serialisation/deserialisation that has been going on for structured messages

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
