### PR TITLE
CAD-488: less serialisation in LogStructured

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -36,7 +36,7 @@ import           Control.Exception.Safe (catchIO)
 import           Control.Monad (foldM, forM_, unless, when, void)
 import           Control.Lens ((^.))
 import           Data.Aeson (FromJSON, ToJSON, Result (Success), Value (..),
-                     fromJSON, toJSON, decode)
+                     fromJSON, toJSON)
 import           Data.Aeson.Text (encodeToLazyText)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
@@ -266,7 +266,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      , "Similar messages elided, " <> pack (show count) <> " total."
                                      , Nothing)
                                 (LogStructured s) ->
-                                     (severity lometa, "", sequence . Right . decode $ s)
+                                     (severity lometa, "", Just . Right $ Object s)
                                 (LogValue name value) ->
                                     if name == ""
                                     then (severity lometa, pack (showSI value), Nothing)

--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -8,10 +8,8 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeSynonymInstances  #-}
 
 module Cardano.BM.Data.Tracer
     ( Tracer (..)
@@ -65,7 +63,7 @@ module Cardano.BM.Data.Tracer
 import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO (..))
 
-import           Data.Aeson (Object, ToJSON (..), Value (..), encode)
+import           Data.Aeson (Object, ToJSON (..), Value (..))
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -386,13 +384,14 @@ to their |ToObject| representation and further traces them as a |LogObject| of t
 trStructured :: (ToObject b, MonadIO m, DefinePrivacyAnnotation b, DefineSeverity b)
              => TracingVerbosity -> Tracer m (LogObject a) -> Tracer m b
 trStructured verb tr = Tracer $ \arg ->
-        let obj = toObject verb arg
-            tracer = if obj == emptyObject then nullTracer else tr
-        in
-        traceWith tracer =<<
-            LogObject <$> pure mempty
-                      <*> mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg)
-                      <*> pure (LogStructured $ encode obj)
+ let
+   obj = toObject verb arg
+   tracer = if obj == emptyObject then nullTracer else tr
+ in traceWith tracer =<<
+    LogObject
+      <$> pure mempty
+      <*> mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg)
+      <*> pure (LogStructured obj)
 
 \end{code}
 

--- a/iohk-monitoring/test/Cardano/BM/Test/LogItem.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/LogItem.lhs
@@ -10,7 +10,8 @@ module Cardano.BM.Test.LogItem (
     tests
   ) where
 
-import           Data.Aeson (encode, decode)
+import           Data.Aeson (Value(..), encode, decode, eitherDecode)
+import           Data.HashMap.Lazy (singleton)
 import           Data.Text (Text)
 
 import           Cardano.BM.Data.Aggregated
@@ -72,10 +73,11 @@ testLogError = do
 testLogStructured :: Assertion
 testLogStructured = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (LogStructured (encode ("value"::Text) ))
+    let m :: LogObject Text = LogObject ["test"] meta . LogStructured $
+          singleton "foo" (String "bar")
     let encoded = encode m
-    let decoded = decode encoded :: Maybe (LogObject Text)
-    assertEqual "unequal" (Just m) decoded
+    let decoded = eitherDecode encoded :: Either String (LogObject Text)
+    assertEqual "unequal" (Right m) decoded
 
 testObserveOpen :: Assertion
 testObserveOpen = do


### PR DESCRIPTION
1. avoid excess serialisation in `LogStructured`
2. resolve some hlints

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
