### PR TITLE
CAD-455:  redo 'env' to carry the app version & git commit

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -16,6 +16,11 @@ module Cardano.BM.Configuration
     , CM.setSeverity
     , CM.getBackends
     , CM.getOption
+    , CM.getMapOption
+    , CM.getTextOption
+    , CM.setOption
+    , CM.setTextOption
+    , CM.updateOption
     , CM.findSubTrace
     , CM.setSubTrace
     , CM.getEKGport
@@ -23,7 +28,7 @@ module Cardano.BM.Configuration
     , CM.getPrometheusBindAddr
     , CM.getGUIport
     , CM.getMonitors
-    , getOptionOrDefault
+    , getTextOptionOrDefault
     , testSeverity
     , CM.evalFilters
     , CM.testSubTrace
@@ -43,12 +48,8 @@ see |Cardano.BM.Configuration.Model| for the implementation.
 
 \label{code:getOptionOrDefault}\index{getOptionOrDefault}
 \begin{code}
-getOptionOrDefault :: CM.Configuration -> Text -> Text -> IO Text
-getOptionOrDefault cg name def = do
-    opt <- CM.getOption cg name
-    case opt of
-        Nothing -> return def
-        Just o -> return o
+getTextOptionOrDefault :: CM.Configuration -> Text -> Text -> IO Text
+getTextOptionOrDefault cg name def = fromMaybe def <$> CM.getTextOption cg name
 
 \end{code}
 

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -27,7 +27,6 @@ module Cardano.BM.Configuration.Model
     , getGraylogPort
     , getLogOutput
     , getMapOption
-    , getMapOption'
     , getMonitors
     , getOption
     , getPrometheusBindAddr
@@ -35,7 +34,6 @@ module Cardano.BM.Configuration.Model
     , getSetupBackends
     , getSetupScribes
     , getTextOption
-    , getTextOption'
     , inspectSeverity
     , minSeverity
     , setAggregatedKind
@@ -364,10 +362,10 @@ getMapOption :: Configuration -> Text -> IO (Maybe Object)
 getMapOption configuration name =
   flip getMapOption' name . cgOptions <$> readMVar (getCG configuration)
 
-updateOption :: Configuration -> Text -> (Value -> Value) -> IO ()
+updateOption :: Configuration -> Text -> (Maybe Value -> Value) -> IO ()
 updateOption configuration name f =
     modifyMVar_ (getCG configuration) $ \cg ->
-        return cg { cgOptions = HM.update (Just . f) name (cgOptions cg) }
+        return cg { cgOptions = HM.alter (Just . f) name (cgOptions cg) }
 
 setOption :: Configuration -> Text -> Value -> IO ()
 setOption configuration name = updateOption configuration name . const

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -13,48 +13,48 @@
 module Cardano.BM.Configuration.Model
     ( Configuration (..)
     , ConfigurationInternal (..)
+    , empty
+    , evalFilters
+    , exportConfiguration
+    , findSubTrace
+    , getAggregatedKind
+    , getBackends
+    , getCachedScribes
+    , getDefaultBackends
+    , getEKGport
+    , getGUIport
+    , getGraylogPort
+    , getLogOutput
+    , getMonitors
+    , getOption
+    , getPrometheusBindAddr
+    , getScribes
+    , getSetupBackends
+    , getSetupScribes
+    , inspectSeverity
+    , minSeverity
+    , setAggregatedKind
+    , setBackends
+    , setCachedScribes
+    , setDefaultAggregatedKind
+    , setDefaultBackends
+    , setDefaultScribes
+    , setEKGport
+    , setGUIport
+    , setGraylogPort
+    , setLogOutput
+    , setMinSeverity
+    , setMonitors
+    , setPrometheusBindAddr
+    , setScribes
+    , setSetupBackends
+    , setSetupScribes
+    , setSeverity
+    , setSubTrace
     , setup
     , setupFromRepresentation
-    , toRepresentation
-    , exportConfiguration
-    , empty
-    , minSeverity
-    , setMinSeverity
-    , inspectSeverity
-    , setSeverity
-    , getBackends
-    , setBackends
-    , getDefaultBackends
-    , setDefaultBackends
-    , setSetupBackends
-    , getSetupBackends
-    , getScribes
-    , setScribes
-    , getCachedScribes
-    , setCachedScribes
-    , setDefaultScribes
-    , setSetupScribes
-    , getSetupScribes
-    , getAggregatedKind
-    , setDefaultAggregatedKind
-    , setAggregatedKind
-    , getOption
-    , findSubTrace
-    , setSubTrace
-    , getMonitors
-    , setMonitors
-    , getEKGport
-    , setEKGport
-    , getGraylogPort
-    , setGraylogPort
-    , getPrometheusBindAddr
-    , setPrometheusBindAddr
-    , getGUIport
-    , setGUIport
-    , getLogOutput
-    , setLogOutput
     , testSubTrace
-    , evalFilters
+    , toRepresentation
     ) where
 
 import           Control.Applicative (Alternative ((<|>)))

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -56,7 +56,7 @@ data Representation = Representation
     , hasPrometheus   :: Maybe HostPort
     , hasGUI          :: Maybe Port
     , logOutput       :: Maybe FilePath
-    , options         :: HM.HashMap Text Object
+    , options         :: HM.HashMap Text Value
     }
     deriving (Generic, Show, ToJSON, FromJSON)
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -107,8 +107,8 @@ unitConfigurationStaticRepresentation =
             , hasPrometheus = Just ("localhost", 12799)
             , logOutput = Nothing
             , options =
-                HM.fromList [ ("test1", (HM.singleton "value" "object1"))
-                            , ("test2", (HM.singleton "value" "object2")) ]
+                HM.fromList [ ("test1", Object (HM.singleton "value" "object1"))
+                            , ("test2", Object (HM.singleton "value" "object2")) ]
             }
     in
     encode r @?=
@@ -253,6 +253,7 @@ unitConfigurationParsed = do
                                             ]
         , cgOptions           = HM.fromList
             [ ("mapSubtrace",
+                Object $
                 HM.fromList [("iohk.benchmarking",
                               Object (HM.fromList [("subtrace",String "ObservableTraceSelf")
                                                   ,("contents",Array $ V.fromList
@@ -260,7 +261,8 @@ unitConfigurationParsed = do
                                                         ,String "MonotonicClock"])]))
                             ,("iohk.deadend",
                               Object (HM.fromList [("subtrace",String "NoTrace")]))])
-            , ("mapMonitors", HM.fromList [("chain.creation.block",Object (HM.fromList
+            , ("mapMonitors", Object $
+                              HM.fromList [("chain.creation.block",Object (HM.fromList
                                             [("monitor",String "((time > (23 s)) Or (time < (17 s)))")
                                             ,("actions",Array $ V.fromList
                                                 [ String "CreateMessage Warning \"chain.creation\""
@@ -272,19 +274,22 @@ unitConfigurationParsed = do
                                                 [ String "CreateMessage Warning \"the observable has been too long too high!\""
                                                 , String "SetGlobalMinimalSeverity Info"
                                                 ])]))])
-            , ("mapSeverity", HM.fromList [("iohk.startup",String "Debug")
+            , ("mapSeverity", Object $
+                              HM.fromList [("iohk.startup",String "Debug")
                                           ,("iohk.background.process",String "Error")
                                           ,("iohk.testing.uncritical",String "Warning")])
-            , ("mapAggregatedkinds", HM.fromList [("iohk.interesting.value",
+            , ("mapAggregatedkinds", Object $
+                                     HM.fromList [("iohk.interesting.value",
                                                         String "EwmaAK {alpha = 0.75}")
                                                  ,("iohk.background.process",
                                                         String "StatsAK")])
-            , ("cfokey",HM.fromList [("value",String "Release-1.0.0")])
-            , ("mapScribes", HM.fromList [("iohk.interesting.value",
+            , ("cfokey", Object $ HM.fromList [("value",String "Release-1.0.0")])
+            , ("mapScribes", Object $ HM.fromList [("iohk.interesting.value",
                                             Array $ V.fromList [String "StdoutSK::stdout"
                                                                ,String "FileSK::testlog"])
                                          ,("iohk.background.process",String "FileSK::testlog")])
-            , ("mapBackends", HM.fromList [("iohk.user.defined",
+            , ("mapBackends", Object $
+                              HM.fromList [("iohk.user.defined",
                                                 Array $ V.fromList [Object (HM.fromList [("kind", String "UserDefinedBK")
                                                                                         ,("name", String "MyBackend")])
                                                                     ,String "KatipBK"


### PR DESCRIPTION
1. allow top-level options to be any `Aeson.Value`, not just  `Aeson.Object`
2. set up Katup to pick up application version and commit instead of version numbers

checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
