### PR TITLE
CAD-517 | katip:  reinstate logging of LogStructured to the unstructured stream

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -266,7 +266,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      , "Similar messages elided, " <> pack (show count) <> " total."
                                      , Nothing)
                                 (LogStructured s) ->
-                                     (severity lometa, "", Just . Right $ Object s)
+                                     (severity lometa, TL.toStrict $ encodeToLazyText s, Just . Right $ Object s)
                                 (LogValue name value) ->
                                     if name == ""
                                     then (severity lometa, pack (showSI value), Nothing)


### PR DESCRIPTION
Restore logging of `LogStructured` payloads to ScText output scribes.

# Note

I find it doubtful that we want to pay the extra JSON encoding cost, regardless of whether we actually use the unstructured pathway for `LogStructured` payloads.

# checklist

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
