### PR TITLE
CAD-517 for text scribes output JSON value if no message

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -260,7 +260,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      in
                                      (severity lometa, text, maylo)
                                 (LogError text) ->
-                                     (severity lometa, text, Nothing)
+                                     (severity lometa, text, Just $ Left loitem)
                                 (LogRepeats count _fir _las) ->
                                      ( severity lometa
                                      , "Similar messages elided, " <> pack (show count) <> " total."
@@ -269,8 +269,8 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      (severity lometa, "", Just . Right $ Object s)
                                 (LogValue name value) ->
                                     if name == ""
-                                    then (severity lometa, pack (showSI value), Nothing)
-                                    else (severity lometa, name <> " = " <> pack (showSI value), Nothing)
+                                    then (severity lometa, pack (showSI value), Just $ Left loitem)
+                                    else (severity lometa, name <> " = " <> pack (showSI value), Just $ Left loitem)
                                 (ObserveDiff _) ->
                                      let text = TL.toStrict (encodeToLazyText loitem)
                                      in
@@ -287,7 +287,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                                      let text = T.concat $ flip map aggregated $ \(name, agg) ->
                                                 "\n" <> name <> ": " <> pack (show agg)
                                     in
-                                    (severity lometa, text, Nothing)
+                                    (severity lometa, text, Just $ Left loitem)
                                 (MonitoringEffect _) ->
                                      let text = TL.toStrict (encodeToLazyText loitem)
                                      in

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -382,7 +382,9 @@ renderTextMsg r =
 
 renderJsonMsg :: (K.LogItem a) => Rendering a -> (Int, TL.Text)
 renderJsonMsg r =
-    let m' = encodeToLazyText $ trimTime $ K.itemJson (verbosity r) (logitem r)
+    let li = logitem r
+        li' = li { KC._itemMessage = "" }
+        m' = encodeToLazyText $ trimTime $ K.itemJson (verbosity r) li'
     in (fromIntegral $ TL.length m', m')
 
 -- keep only two digits for the fraction of seconds


### PR DESCRIPTION
description
-----------

- [ ] scribes with 'ScText' format can output structured value as message; output LogValue as JSON value; structured log output resets "msg" field to avoid duplication


checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
