### PR TITLE
CAD-517:  more structured-vs-plain fixing

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -342,32 +342,35 @@ mkDevNullScribe = do
     let logger _ = pure ()
     pure $ K.Scribe logger (pure ()) (pure . const True)
 
-mkTextFileScribeH :: Handle -> Bool -> IO K.Scribe
-mkTextFileScribeH handler =
-    mkFileScribeH handler formatter
-  where
-    formatter h r =
-        let (_, msg) = renderTextMsg r
-        in TIO.hPutStrLn h $! msg
-mkJsonFileScribeH :: Handle -> Bool -> IO K.Scribe
-mkJsonFileScribeH handler =
-    mkFileScribeH handler formatter
-  where
-    formatter h r =
-        let (_, msg) = renderJsonMsg r
-        in TIO.hPutStrLn h $! msg
+type Formatter a = K.LogItem a => Handle -> Rendering a -> IO Int
+
+textFormatter, jsonFormatter :: Formatter a
+textFormatter h r =
+  let (len, msg) = renderTextMsg r
+  in (TIO.hPutStrLn h $! msg) >> pure len
+jsonFormatter h r =
+  let (len, msg) = renderJsonMsg r
+  in (TIO.hPutStrLn h $! msg) >> pure len
+
+mkTextFileScribeH, mkJsonFileScribeH :: Handle -> Bool -> IO K.Scribe
+mkTextFileScribeH = mkFileScribeH textFormatter
+mkJsonFileScribeH = mkFileScribeH jsonFormatter
+
+mkTextFileScribe, mkJsonFileScribe :: Maybe RotationParameters -> FileDescription -> Bool -> IO K.Scribe
+mkTextFileScribe = mkFileScribe textFormatter
+mkJsonFileScribe = mkFileScribe jsonFormatter
 
 mkFileScribeH
-    :: Handle
-    -> (forall a . K.LogItem a => Handle -> Rendering a -> IO ())
+    :: (forall a. Formatter a)
+    -> Handle
     -> Bool
     -> IO K.Scribe
-mkFileScribeH h formatter colorize = do
+mkFileScribeH formatter h colorize = do
     hSetBuffering h LineBuffering
     locklocal <- newMVar ()
     let logger :: forall a. K.LogItem a =>  K.Item a -> IO ()
         logger item = withMVar locklocal $ \_ ->
-                        formatter h (Rendering colorize K.V0 item)
+                        void $ formatter h (Rendering colorize K.V0 item)
     pure $ K.Scribe logger (hClose h) (pure . const True)
 
 data Rendering a = Rendering { colorize  :: Bool
@@ -407,31 +410,13 @@ trimTime (Object o) = Object $ HM.adjust
     jformat = "%FT%T%2QZ"
 trimTime v = v
 
-mkTextFileScribe :: Maybe RotationParameters -> FileDescription -> Bool -> IO K.Scribe
-mkTextFileScribe rotParams fdesc =
-    mkFileScribe rotParams fdesc formatter
-  where
-    formatter :: (K.LogItem a) => Handle -> Rendering a -> IO Int
-    formatter hdl r = TIO.hPutStrLn hdl tmsg >> pure mlen
-      where (mlen, tmsg) = renderTextMsg r
-
-mkJsonFileScribe :: Maybe RotationParameters -> FileDescription -> Bool -> IO K.Scribe
-mkJsonFileScribe rotParams fdesc =
-    mkFileScribe rotParams fdesc formatter
-  where
-    formatter :: (K.LogItem a) => Handle -> Rendering a -> IO Int
-    formatter h r = do
-        let (mlen, tmsg) = renderJsonMsg r
-        TIO.hPutStrLn h tmsg
-        return mlen
-
 mkFileScribe
-    :: Maybe RotationParameters
+    :: (forall a . K.LogItem a => Handle -> Rendering a -> IO Int)
+    -> Maybe RotationParameters
     -> FileDescription
-    -> (forall a . K.LogItem a => Handle -> Rendering a -> IO Int)
     -> Bool
     -> IO K.Scribe
-mkFileScribe (Just rotParams) fdesc formatter colorize = do
+mkFileScribe formatter (Just rotParams) fdesc colorize = do
     let prefixDir = prefixPath fdesc
     createDirectoryIfMissing True prefixDir
         `catchIO` prtoutException ("cannot log prefix directory: " ++ prefixDir)
@@ -464,7 +449,7 @@ mkFileScribe (Just rotParams) fdesc formatter colorize = do
                         return (h, bytes', rottime)
     return $ K.Scribe logger finalizer (pure . const True)
 -- log rotation disabled.
-mkFileScribe Nothing fdesc formatter colorize = do
+mkFileScribe formatter Nothing fdesc colorize = do
     let prefixDir = prefixPath fdesc
     createDirectoryIfMissing True prefixDir
         `catchIO` prtoutException ("cannot create prefix directory: " ++ prefixDir)


### PR DESCRIPTION
1. deal with structured-ness in `renderTextMessage`, which covers all scribes, not just `FileSk`
2. factor formatters a bit


checklist
---------

- [x] compiles (`cabal new-clean; cabal new-build`)
- [x] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
