### PR TITLE
CAD-328 context name in Trace

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -241,7 +241,7 @@ dumpBuffer sb trace = do
         threadDelay 25000000  -- 25 seconds
         buf <- readLogBuffer sb
         forM_ buf $ \(logname, LogObject _ lometa locontent) -> do
-            let tr' = modifyName (\n -> ["#buffer"] <> n <> [logname]) tr
+            let tr' = modifyName (\n -> "#buffer" <> "." <> n <> "." <> logname) tr
             traceNamedObject tr' (lometa, locontent)
         loop tr
 \end{code}
@@ -371,7 +371,7 @@ instance Transformable Text IO Pet where
     -- transform to textual representation using |show|
     trTransformer TextualRepresentation _v tr = Tracer $ \pet -> do
         meta <- mkLOMeta Info Public
-        traceWith tr $ LogObject ["pet"] meta $ (LogMessage . pack . show) pet
+        traceWith tr $ ("pet", LogObject "pet" meta $ (LogMessage . pack . show) pet)
     trTransformer _ _verb _tr = nullTracer
 
 -- default privacy annotation: Public

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -95,7 +95,7 @@ instance ToJSON a => IsEffectuator Log a where
         let logMVar = getK katip
         c <- configuration <$> readMVar logMVar
         setupScribes <- getSetupScribes c
-        selscribes <- getScribes c (lo2name item)
+        selscribes <- getScribes c (loName item)
         let selscribesFiltered =
                 case item of
                     LogObject _ (LOMeta _ _ _ _ Confidential) (LogMessage _)
@@ -298,7 +298,7 @@ passN backend katip (LogObject loname lometa loitem) = do
                     unless (msg == "" && isNothing payload) $ do
                         let threadIdText = KC.ThreadIdText $ tid lometa
                         let itemTime = tstamp lometa
-                        let localname = loname
+                        let localname = [loname]
                         let itemKatip = K.Item {
                                   _itemApp       = env ^. KC.logEnvApp
                                 , _itemEnv       = env ^. KC.logEnvEnv

--- a/iohk-monitoring/src/Cardano/BM/Backend/LogBuffer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/LogBuffer.lhs
@@ -26,7 +26,7 @@ import           System.IO (stderr)
 import           Cardano.BM.Data.Backend (BackendKind (LogBufferBK),
                      IsBackend (..), IsEffectuator (..))
 import           Cardano.BM.Data.LogItem (LOContent (..), LoggerName,
-                     LogObject (..), loname2text)
+                     LogObject (..))
 
 \end{code}
 %endif
@@ -69,10 +69,10 @@ Function |effectuate| is called to pass in a |LogObject| for log buffering.
 instance IsEffectuator LogBuffer a where
     effectuate buffer lo@(LogObject loname _lometa (LogValue lvname _lvalue)) =
         modifyMVar_ (getLogBuf buffer) $ \currentBuffer ->
-            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname <> "." <> lvname) lo $ logBuffer currentBuffer
+            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname <> "." <> lvname) lo $ logBuffer currentBuffer
     effectuate buffer lo@(LogObject loname _lometa _logitem) =
         modifyMVar_ (getLogBuf buffer) $ \currentBuffer ->
-            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname2text loname) lo $ logBuffer currentBuffer
+            return $! LogBufferInternal $ HM.insert ("#buffered." <> loname) lo $ logBuffer currentBuffer
 
     handleOverflow _ = TIO.hPutStrLn stderr "Notice: overflow in LogBuffer, dropping log items!"
 

--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -24,7 +24,6 @@ module Cardano.BM.Data.LogItem
   , mapLogObject
   , mapLOContent
   , loContentEq
-  , lo2name
   , loname2text
   )
   where
@@ -36,7 +35,9 @@ import           Data.Aeson (FromJSON (..), ToJSON (..), Value (..), (.=),
                      (.:), object, withText, withObject)
 import           Data.Aeson.Types (Object, Parser)
 import           Data.Function (on)
+import           Data.List (foldl')
 import           Data.Maybe (fromMaybe)
+import qualified Data.Text as T
 import           Data.Text (Text, pack, stripPrefix)
 import           Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import           Data.Time.Clock (UTCTime (..), getCurrentTime)
@@ -64,7 +65,7 @@ type LoggerName = Text
 
 \begin{code}
 data LogObject a = LogObject
-                     { loName    :: [LoggerName]
+                     { loName    :: LoggerName
                      , loMeta    :: !LOMeta
                      , loContent :: !(LOContent a)
                      } deriving (Show, Eq)
@@ -400,17 +401,7 @@ loContentEq = (==) `on` loContent
 
 \subsubsection{Render context name as text}
 \label{code:loname2text}\index{loname2text}
-\label{code:lo2name}\index{lo2name}
 \begin{code}
-lo2name :: LogObject a -> Text
-lo2name (LogObject loname _ _) = loname2text loname
 loname2text :: [LoggerName] -> Text
-loname2text [] = ""
-loname2text (nm : nms) = intercalate nm "." nms
-  where
-    intercalate :: Text -> Text -> [Text] -> Text
-    intercalate acc _ [] = acc
-    intercalate acc sep (a : as) = intercalate
-        (acc <> sep <> a)
-        sep as
+loname2text nms = T.init $ foldl' (\el acc -> acc <> "." <> el) "" nms
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Trace.lhs
@@ -5,7 +5,6 @@
 %if style == newcode
 \begin{code}
 {-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.BM.Data.Trace
@@ -13,15 +12,15 @@ module Cardano.BM.Data.Trace
   )
   where
 
-import           Cardano.BM.Data.LogItem (LogObject(..))
-import           Cardano.BM.Data.Tracer (Tracer(..))
+import           Cardano.BM.Data.LogItem (LogObject(..), LoggerName)
+import           Control.Tracer
 
 \end{code}
 %endif
 
 \subsubsection{Trace}\label{code:Trace}\index{Trace}
-A |Trace m a| is a |Tracer m (LogObject a)|.
+A |Trace m a| is a |Tracer| containing the context name and a |LogObject a|.
 \begin{code}
 
-type Trace m a = Tracer m (LogObject a)
+type Trace m a = Tracer m (LoggerName, LogObject a)
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Data/Transformers.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Transformers.lhs
@@ -9,6 +9,7 @@
 module Cardano.BM.Data.Transformers
   ( liftCounting
   , liftFolding
+  , setHostname
   )
   where
 
@@ -31,13 +32,14 @@ Lift a 'Counting' tracer into a 'Trace' of 'PureI' messages.
 
 liftCounting
   :: forall m a
-  .  LOMeta -> [LoggerName] -> Text -> Trace m a
-  -> Tracer m (Counting (LogObject a))
+  .  LOMeta -> LoggerName -> Text -> Trace m a
+  -> Tracer m (Counting (LoggerName, LogObject a))
 liftCounting meta name desc tr = Tracer (traceIncrement tr)
  where
-   traceIncrement :: Trace m a -> Counting (LogObject a) -> m ()
+   traceIncrement :: Trace m a -> Counting (LoggerName, LogObject a) -> m ()
    traceIncrement t (Counting n) =
-     traceWith t . LogObject name meta . LogValue desc . PureI $ fromIntegral n
+    --  traceWith t . LogObject name meta . LogValue desc . PureI $ fromIntegral n
+     traceWith t $ (name, LogObject name meta . LogValue desc . PureI $ fromIntegral n)
 
 \end{code}
 
@@ -51,12 +53,23 @@ thereby specialising it to 'Integral'.
 liftFolding
   :: forall m f a
   .  (Integral f) -- TODO:  generalise
-  => LOMeta -> [LoggerName] -> Text -> Trace m a
-  -> Tracer m (Folding (LogObject a) f)
+  => LOMeta -> LoggerName -> Text -> Trace m a
+  -> Tracer m (Folding (LoggerName, LogObject a) f)
 liftFolding meta name desc tr = Tracer (traceIncrement tr)
  where
-   traceIncrement :: Trace m a -> Folding (LogObject a) f -> m ()
+   traceIncrement :: Trace m a -> Folding (LoggerName, LogObject a) f -> m ()
    traceIncrement t (Folding f) =
-     traceWith t . LogObject name meta . LogValue desc . PureI $ fromIntegral f
+     traceWith t $ (name, LogObject name meta . LogValue desc . PureI $ fromIntegral f)
+
+\end{code}
+
+\subsubsection{Transformer for setting hostname annotation}
+\label{code:setHostname}
+\index{setHostname}
+The hostname annotation of the |LogObject| can be altered.
+\begin{code}
+setHostname :: Text -> Trace m a -> Trace m a
+setHostname hn tr = Tracer $ \(ctx, lo@(LogObject _ln meta _lc)) ->
+    traceWith tr (ctx, lo { loMeta = meta { hostname = hn }})
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Trace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Trace.lhs
@@ -36,7 +36,6 @@ import qualified Control.Concurrent.STM.TVar as STM
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Control.Monad.STM as STM
 import           Data.Aeson.Text (encodeToLazyText)
-import           Data.Functor.Contravariant (Contravariant (..))
 import           Data.Monoid ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
@@ -45,9 +44,9 @@ import           System.IO.Unsafe (unsafePerformIO)
 
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity
-import           Cardano.BM.Data.Trace
-import           Cardano.BM.Data.Tracer (Tracer (..), natTracer, nullTracer,
-                     traceWith)
+import           Cardano.BM.Data.Trace (Trace)
+import           Cardano.BM.Data.Tracer (Tracer (..), contramap, natTracer,
+                     nullTracer, traceWith)
 
 \end{code}
 %endif
@@ -55,8 +54,8 @@ import           Cardano.BM.Data.Tracer (Tracer (..), natTracer, nullTracer,
 \subsubsection{Utilities}
 Natural transformation from monad |m| to monad |n|.
 \begin{code}
-natTrace :: (forall x . m x -> n x) -> Trace m a -> Trace n a
-natTrace nat basetrace = natTracer nat basetrace
+natTrace :: (forall x . m x -> n x) -> Tracer m (LoggerName,LogObject a) -> Tracer n (LoggerName,LogObject a)
+natTrace = natTracer
 
 \end{code}
 
@@ -64,8 +63,10 @@ natTrace nat basetrace = natTracer nat basetrace
 A new context name is added.
 \begin{code}
 appendName :: LoggerName -> Trace m a -> Trace m a
-appendName name =
-    modifyName (\prev -> [name] <> prev)
+appendName name tr = Tracer $ \(names0, lo) ->
+    let names = if names0 == T.empty then name else name <> "." <> names0
+    in
+    traceWith tr (names, lo)
 
 \end{code}
 
@@ -73,19 +74,19 @@ appendName name =
 The context name is overwritten.
 \begin{code}
 modifyName
-    :: ([LoggerName] -> [LoggerName])
-    -> Tracer m (LogObject a)
-    -> Tracer m (LogObject a)
+    :: (LoggerName -> LoggerName)
+    -> Trace m a
+    -> Trace m a
 modifyName k = contramap f
   where
-    f (LogObject name meta item) = LogObject (k name) meta item
+    f (names0, lo) = (k names0, lo)
 
 \end{code}
 
 \subsubsection{Contramap a trace and produce the naming context}
 \begin{code}
-named :: Tracer m (LogObject a) -> Tracer m (LOMeta, LOContent a)
-named = contramap $ uncurry (LogObject mempty)
+named :: Tracer m (LoggerName,LogObject a) -> Tracer m (LOMeta, LOContent a)
+named = contramap $ \(meta, loc) -> (mempty, LogObject mempty meta loc)
 
 \end{code}
 
@@ -120,16 +121,16 @@ locallock = unsafePerformIO $ newMVar ()
 \end{code}
 
 \begin{code}
-stdoutTrace :: Tracer IO (LogObject T.Text)
-stdoutTrace = Tracer $ \(LogObject loname _ lc) ->
+stdoutTrace :: Trace IO T.Text
+stdoutTrace = Tracer $ \(ctx, LogObject _loname _ lc) ->
     withMVar locallock $ \_ ->
         case lc of
             (LogMessage logItem) ->
-                    output loname logItem
+                    output ctx logItem
             obj ->
-                    output loname $ toStrict (encodeToLazyText obj)
+                    output ctx $ toStrict (encodeToLazyText obj)
   where
-    output nm msg = TIO.putStrLn $ loname2text nm <> " :: " <> msg
+    output nm msg = TIO.putStrLn $ nm <> " :: " <> msg
 
 \end{code}
 

--- a/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
+++ b/iohk-monitoring/test/Cardano/BM/Arbitrary.hs
@@ -70,9 +70,9 @@ instance Arbitrary a => Arbitrary (LOContent a) where
 instance Arbitrary a => Arbitrary (LogObject a) where
   arbitrary = do
     loName <- elements
-      [ ["logger", "for", "nothing"]
-      , ["tracer", "of"]
-      , ["things"]
+      [ "logger.for.nothing"
+      , "tracer.of"
+      , "things"
       ]
     loMeta <- arbitrary
     loContent :: LOContent a <- arbitrary

--- a/iohk-monitoring/test/Cardano/BM/Test/Aggregated.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Aggregated.lhs
@@ -73,10 +73,10 @@ lometa = unsafePerformIO $ mkLOMeta Debug Public
 prop_Aggregation_comm :: Integer -> Integer -> Aggregated -> Property
 prop_Aggregation_comm v1 v2 ag =
     let ns = utc2ns $ tstamp lometa
-        Right agg2 = updateAggregation (PureI v2) ag ns Nothing
-        Right agg1 = updateAggregation (PureI v1) ag ns Nothing
-        Right (AggregatedStats stats21) = updateAggregation (PureI v1) agg2 ns Nothing
-        Right (AggregatedStats stats12) = updateAggregation (PureI v2) agg1 ns Nothing
+        Right agg2 = updateAggregation (PureI v2) ag ns
+        Right agg1 = updateAggregation (PureI v1) ag ns
+        Right (AggregatedStats stats21) = updateAggregation (PureI v1) agg2 ns
+        Right (AggregatedStats stats12) = updateAggregation (PureI v2) agg1 ns
     in
     fbasic stats21 === fbasic stats12 .&&.
     (v1 == v2) `implies` (flast stats21 === flast stats12)
@@ -93,7 +93,7 @@ implies p1 p2 = property (not p1) .||. p2
 unitAggregationInitialMinus1 :: Assertion
 unitAggregationInitialMinus1 = do
     let ns = utc2ns $ tstamp lometa
-        Right (AggregatedStats stats1) = updateAggregation (-1) firstStateAggregatedStats ns Nothing
+        Right (AggregatedStats stats1) = updateAggregation (-1) firstStateAggregatedStats ns
     flast stats1 @?= (-1)
     (fbasic stats1) @?= BaseStats (-1) 0 2 (-0.5) 0.5
     (fdelta stats1) @?= BaseStats (-1) (-1) 2 (-1) 0
@@ -101,7 +101,7 @@ unitAggregationInitialMinus1 = do
 unitAggregationInitialPlus1 :: Assertion
 unitAggregationInitialPlus1 = do
     let ns = utc2ns $ tstamp lometa
-        Right (AggregatedStats stats1) = updateAggregation 1 firstStateAggregatedStats ns Nothing
+        Right (AggregatedStats stats1) = updateAggregation 1 firstStateAggregatedStats ns
     flast stats1 @?= 1
     (fbasic stats1) @?= BaseStats 0 1 2 0.5 0.5
     (fdelta stats1) @?= BaseStats 1 1 2 1 0
@@ -109,7 +109,7 @@ unitAggregationInitialPlus1 = do
 unitAggregationInitialZero :: Assertion
 unitAggregationInitialZero = do
     let ns = utc2ns $ tstamp lometa
-        Right (AggregatedStats stats1) = updateAggregation 0 firstStateAggregatedStats ns Nothing
+        Right (AggregatedStats stats1) = updateAggregation 0 firstStateAggregatedStats ns
     flast stats1 @?= 0
     (fbasic stats1) @?= BaseStats 0 0 2 0 0
     (fdelta stats1) @?= BaseStats 0 0 2 0 0
@@ -117,8 +117,8 @@ unitAggregationInitialZero = do
 unitAggregationInitialPlus1Minus1 :: Assertion
 unitAggregationInitialPlus1Minus1 = do
     let ns = utc2ns $ tstamp lometa
-        Right agg1 = updateAggregation (PureI 1) firstStateAggregatedStats ns Nothing
-        Right (AggregatedStats stats1) = updateAggregation (PureI (-1)) agg1 ns Nothing
+        Right agg1 = updateAggregation (PureI 1) firstStateAggregatedStats ns
+        Right (AggregatedStats stats1) = updateAggregation (PureI (-1)) agg1 ns
     (fbasic stats1) @?= BaseStats (PureI (-1)) (PureI 1) 3   0.0  2.0
     (fdelta stats1) @?= BaseStats (PureI (-2)) (PureI 1) 3 (-0.5) 4.5
 
@@ -128,24 +128,24 @@ unitAggregationStepwise = do
     -- putStrLn (show stats0)
     threadDelay 50000   -- 0.05 s
     t1 <- mkLOMeta Debug Public
-    Right stats1 <- pure $ updateAggregation (Bytes 5000) stats0 (utc2ns $ tstamp t1) Nothing
+    Right stats1 <- pure $ updateAggregation (Bytes 5000) stats0 (utc2ns $ tstamp t1)
     -- putStrLn (show stats1)
     -- showTimedMean stats1
     threadDelay 50000   -- 0.05 s
     t2 <- mkLOMeta Debug Public
-    Right stats2 <- pure $ updateAggregation (Bytes 1000) stats1 (utc2ns $ tstamp t2) Nothing
+    Right stats2 <- pure $ updateAggregation (Bytes 1000) stats1 (utc2ns $ tstamp t2)
     -- putStrLn (show stats2)
     -- showTimedMean stats2
     checkTimedMean stats2
     threadDelay 50000   -- 0.05 s
     t3 <- mkLOMeta Debug Public
-    Right stats3 <- pure $ updateAggregation (Bytes 3000) stats2 (utc2ns $ tstamp t3) Nothing
+    Right stats3 <- pure $ updateAggregation (Bytes 3000) stats2 (utc2ns $ tstamp t3)
     -- putStrLn (show stats3)
     -- showTimedMean stats3
     checkTimedMean stats3
     threadDelay 50000   -- 0.05 s
     t4 <- mkLOMeta Debug Public
-    Right stats4 <- pure $ updateAggregation (Bytes 1000) stats3 (utc2ns $ tstamp t4) Nothing
+    Right stats4 <- pure $ updateAggregation (Bytes 1000) stats3 (utc2ns $ tstamp t4)
     -- putStrLn (show stats4)
     -- showTimedMean stats4
     checkTimedMean stats4

--- a/iohk-monitoring/test/Cardano/BM/Test/LogItem.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/LogItem.lhs
@@ -49,7 +49,7 @@ tests = testGroup "Testing en/de-coding of LogItem" [
 testLogMessage :: Assertion
 testLogMessage = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (LogMessage "hello")
+    let m :: LogObject Text = LogObject "test" meta (LogMessage "hello")
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -57,7 +57,7 @@ testLogMessage = do
 testLogValue :: Assertion
 testLogValue = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (LogValue "value" (PureI 42))
+    let m :: LogObject Text = LogObject "test" meta (LogValue "value" (PureI 42))
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -65,7 +65,7 @@ testLogValue = do
 testLogError :: Assertion
 testLogError = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (LogError "error")
+    let m :: LogObject Text = LogObject "test" meta (LogError "error")
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -73,7 +73,7 @@ testLogError = do
 testLogStructured :: Assertion
 testLogStructured = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta . LogStructured $
+    let m :: LogObject Text = LogObject "test" meta . LogStructured $
           singleton "foo" (String "bar")
     let encoded = encode m
     let decoded = eitherDecode encoded :: Either String (LogObject Text)
@@ -84,7 +84,7 @@ testObserveOpen = do
     meta <- mkLOMeta Info Public
     let cs = CounterState [Counter StatInfo "some" (Bytes 789),
                            Counter RTSStats "gcn" (PureI 42)]
-    let m :: LogObject Text = LogObject ["test"] meta (ObserveOpen cs)
+    let m :: LogObject Text = LogObject "test" meta (ObserveOpen cs)
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -94,7 +94,7 @@ testObserveDiff = do
     meta <- mkLOMeta Info Public
     let cs = CounterState [Counter StatInfo "some" (Bytes 789),
                            Counter RTSStats "gcn" (PureI 42)]
-    let m :: LogObject Text = LogObject ["test"] meta (ObserveDiff cs)
+    let m :: LogObject Text = LogObject "test" meta (ObserveDiff cs)
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -104,7 +104,7 @@ testObserveClose = do
     meta <- mkLOMeta Info Public
     let cs = CounterState [Counter StatInfo "some" (Bytes 789),
                            Counter RTSStats "gcn" (PureI 42)]
-    let m :: LogObject Text = LogObject ["test"] meta (ObserveClose cs)
+    let m :: LogObject Text = LogObject "test" meta (ObserveClose cs)
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -114,7 +114,7 @@ testAggregatedMessage = do
     meta <- mkLOMeta Info Public
     let as = [("test1", AggregatedEWMA (EWMA 0.8 (PureD 47.32))),
               ("test2", AggregatedStats (Stats 1 4 (BaseStats 0 1 2 0.5 0.5) (BaseStats 1 1 2 1 0) (BaseStats (-1) 3 2 77 0)))]
-    let m :: LogObject Text = LogObject ["test"] meta (AggregatedMessage as)
+    let m :: LogObject Text = LogObject "test" meta (AggregatedMessage as)
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -122,7 +122,7 @@ testAggregatedMessage = do
 testMonitoringEffect :: Assertion
 testMonitoringEffect = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (MonitoringEffect (MonitorAlterGlobalSeverity Notice))
+    let m :: LogObject Text = LogObject "test" meta (MonitoringEffect (MonitorAlterGlobalSeverity Notice))
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -130,7 +130,7 @@ testMonitoringEffect = do
 testCommand :: Assertion
 testCommand = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta (Command (DumpBufferedTo KatipBK))
+    let m :: LogObject Text = LogObject "test" meta (Command (DumpBufferedTo KatipBK))
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded
@@ -138,7 +138,7 @@ testCommand = do
 testKillPill :: Assertion
 testKillPill = do
     meta <- mkLOMeta Info Public
-    let m :: LogObject Text = LogObject ["test"] meta KillPill
+    let m :: LogObject Text = LogObject "test" meta KillPill
     let encoded = encode m
     let decoded = decode encoded :: Maybe (LogObject Text)
     assertEqual "unequal" (Just m) decoded

--- a/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Structured.lhs
@@ -48,7 +48,7 @@ Trace textual messages. This is not structured logging and only here for referen
 logSimpleText :: Assertion
 logSimpleText = do
     cfg <- defaultConfigTesting
-    baseTrace :: Tracer IO (LogObject Text) <- Setup.setupTrace (Right cfg) "logSimpleText"
+    baseTrace :: Trace IO Text <- Setup.setupTrace (Right cfg) "logSimpleText"
 
     traceWith (toLogObject baseTrace) ("This is a simple message." :: Text)
     traceWith (toLogObject baseTrace) (".. and another!" :: String)
@@ -86,7 +86,7 @@ instance Transformable Text IO Pet where
     -- transform to textual representation using |show|
     trTransformer TextualRepresentation _v tr = Tracer $ \pet -> do
         meta <- mkLOMeta Info Public
-        traceWith tr $ LogObject ["pet"] meta $ (LogMessage . pack . show) pet
+        traceWith tr $ ("pet", LogObject "pet" meta $ (LogMessage . pack . show) pet)
     trTransformer _ _verb _tr = nullTracer
 
 -- default privacy annotation: Public
@@ -124,7 +124,7 @@ logStructured = do
 logStructuredStdout :: Assertion
 logStructuredStdout = do
     cfg <- defaultConfigStdout
-    baseTrace :: Tracer IO (LogObject Text) <- Setup.setupTrace (Right cfg) "logStructured"
+    baseTrace :: Trace IO Text <- Setup.setupTrace (Right cfg) "logStructured"
 
     let noticeTracer = severityNotice baseTrace
     let confidentialTracer = annotateConfidential baseTrace
@@ -165,7 +165,7 @@ instance Transformable Text IO Material where
     -- transform to textual representation using |show|
     trTransformer TextualRepresentation _v tr = Tracer $ \mat -> do
         meta <- mkLOMeta Info Public
-        traceWith tr $ LogObject ["material"] meta $ (LogMessage . pack . show) mat
+        traceWith tr $ ("material", LogObject "material" meta $ (LogMessage . pack . show) mat)
     trTransformer _ _verb _tr = nullTracer
 
 instance DefinePrivacyAnnotation Material where

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -464,7 +464,7 @@ unitTraceInFork = do
     Async.wait $ work1
 
     res <- STM.readTVarIO msgs
-    let names@(_: namesTail) = map lo2name res
+    let names@(_: namesTail) = map loName res
     -- each trace should have its own name and log right after the other
     assertBool
         ("Consecutive loggernames are not different: " ++ show names)
@@ -496,7 +496,7 @@ stressTraceInFork = do
     forM_ ts Async.wait
 
     res <- STM.readTVarIO msgs
-    let resNames = map lo2name res
+    let resNames = map loName res
     let frequencyMap = fromListWith (+) [(x, 1) | x <- resNames]
 
     -- each trace should have traced totalMessages' messages
@@ -541,7 +541,7 @@ unitAppendName = do
         trace2 = appendName bigName trace1
     forM_ [basetrace, trace1, trace2] $ (flip logInfo msg)
     res <- reverse <$> STM.readTVarIO msgs
-    let loggernames = map lo2name res
+    let loggernames = map loName res
     assertBool
         ("AppendName did not work properly. The loggernames for the messages are: " ++
             show loggernames)

--- a/plugins/backend-aggregation/src/Cardano/BM/Backend/Aggregation.lhs
+++ b/plugins/backend-aggregation/src/Cardano/BM/Backend/Aggregation.lhs
@@ -45,6 +45,7 @@ import           Cardano.BM.Data.Counter (Counter (..), CounterState (..),
                      nameCounter)
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity (Severity (..))
+import           Cardano.BM.Data.Tracer (traceWith)
 import           Cardano.BM.Plugin
 import qualified Cardano.BM.Trace as Trace
 
@@ -78,22 +79,7 @@ data AggregationInternal a = AggregationInternal
 \subsubsection{Relation from context name to aggregated statistics}
 We keep the aggregated values (|Aggregated|) for a named context in a |HashMap|.
 \begin{code}
-type AggregationMap = HM.HashMap Text AggregatedExpanded
-
-\end{code}
-
-\subsubsection{Info for Aggregated operations}\label{code:AggregatedExpanded}\index{AggregatedExpanded}
-Apart from the |Aggregated| we keep some valuable info regarding to them; such as when
-was the last time it was sent.
-\begin{code}
-type Timestamp = Word64
-
-data AggregatedExpanded = AggregatedExpanded
-                            { aeAggregated :: !Aggregated
-                            , aeResetAfter :: !(Maybe Word64)
-                            , aeLastSent   :: {-# UNPACK #-} !Timestamp
-                            }
-
+type AggregationMap = HM.HashMap Text Aggregated
 \end{code}
 
 \subsubsection{|Aggregation| implements |effectuate|}\index{Aggregation!instance of IsEffectuator}
@@ -166,7 +152,7 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
     Async.async $ qProc trace aggMap
   where
     {-@ lazy qProc @-}
-    qProc trace aggregatedMap = do
+    qProc trace aggregatedMap =
         processQueue
             aggregationQueue
             processAggregated
@@ -175,8 +161,7 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
 
     processAggregated lo@(LogObject loname lm _) (trace, aggregatedMap) = do
         (updatedMap, aggregations) <- update lo aggregatedMap trace
-        unless (null aggregations) $
-            sendAggregated trace (LogObject loname lm (AggregatedMessage aggregations))
+        sendAggregated trace loname (severity lm) aggregations
         return (trace, updatedMap)
 
     createNupdate :: Text -> Measurable -> LOMeta -> AggregationMap -> IO (Either Text Aggregated)
@@ -186,30 +171,23 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
                 -- if Aggregated does not exist; initialize it.
                 aggregatedKind <- getAggregatedKind conf name
                 case aggregatedKind of
-                    StatsAK      -> return $ Right $ singletonStats value
-                    EwmaAK aEWMA -> do
-                        let initEWMA = EmptyEWMA aEWMA
-                        return $ AggregatedEWMA <$> ewma initEWMA value
-            Just a -> return $ updateAggregation value (aeAggregated a) (utc2ns $ tstamp lme) (aeResetAfter a)
+                    StatsAK      -> return $ Right (singletonStats value)
+                    EwmaAK aEWMA ->
+                        return $ AggregatedEWMA <$> ewma (EmptyEWMA aEWMA) value
+            Just a -> return $ updateAggregation value a (utc2ns $ tstamp lme)
 
     update :: LogObject a
            -> AggregationMap
-            -> Trace.Trace IO a
+           -> Trace.Trace IO a
            -> IO (AggregationMap, [(Text, Aggregated)])
     update (LogObject loname lme (LogValue iname value)) agmap trace = do
-        let fullname = loname2text loname <> "." <> iname
+        let fullname = loname <> "." <> iname
         eitherAggregated <- createNupdate fullname value lme agmap
         case eitherAggregated of
             Right aggregated -> do
-                now <- getMonotonicTimeNSec
-                let aggregatedX = AggregatedExpanded {
-                                    aeAggregated = aggregated
-                                  , aeResetAfter = Nothing
-                                  , aeLastSent = now
-                                  }
-                    namedAggregated = [(iname, aeAggregated aggregatedX)]
-                    updatedMap = HM.alter (const $ Just $ aggregatedX) fullname agmap
-                return (updatedMap, namedAggregated)
+                sendAggregated trace fullname (severity lme) [(iname, aggregated)]
+                let updatedMap = HM.alter (const $ Just $ aggregated) fullname agmap
+                return (updatedMap, [])
             Left w -> do
                 let trace' = Trace.appendName "update" trace
                 Trace.traceNamedObject trace' =<<
@@ -218,27 +196,21 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
                 return (agmap, [])
 
     update (LogObject loname lme (ObserveDiff counterState)) agmap trace =
-        updateCounters (csCounters counterState) lme (loname2text loname, "diff") agmap [] trace
+        updateCounters (csCounters counterState) lme (loname, "diff") agmap [] trace
     update (LogObject loname lme (ObserveOpen counterState)) agmap trace =
-        updateCounters (csCounters counterState) lme (loname2text loname, "open") agmap [] trace
+        updateCounters (csCounters counterState) lme (loname, "open") agmap [] trace
     update (LogObject loname lme (ObserveClose counterState)) agmap trace =
-        updateCounters (csCounters counterState) lme (loname2text loname, "close") agmap [] trace
+        updateCounters (csCounters counterState) lme (loname, "close") agmap [] trace
 
     update (LogObject loname lme (LogMessage _)) agmap trace = do
         let iname  = pack $ show (severity lme)
-        let fullname = (loname2text loname) <> "." <> iname
+        let fullname = loname <> "." <> iname
         eitherAggregated <- createNupdate fullname (PureI 0) lme agmap
         case eitherAggregated of
             Right aggregated -> do
-                now <- getMonotonicTimeNSec
-                let aggregatedX = AggregatedExpanded {
-                                    aeAggregated = aggregated
-                                  , aeResetAfter = Nothing
-                                  , aeLastSent = now
-                                  }
-                    namedAggregated = [(iname, aeAggregated aggregatedX)]
-                    updatedMap = HM.alter (const $ Just $ aggregatedX) fullname agmap
-                return (updatedMap, namedAggregated)
+                sendAggregated trace fullname (severity lme) [(iname, aggregated)]
+                let updatedMap = HM.alter (const $ Just $ aggregated) fullname agmap
+                return (updatedMap, [])
             Left w -> do
                 let trace' = Trace.appendName "update" trace
                 Trace.traceNamedObject trace' =<<
@@ -256,7 +228,7 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
                    -> [(Text, Aggregated)]
                    -> Trace.Trace IO a
                    -> IO (AggregationMap, [(Text, Aggregated)])
-    updateCounters [] _ _ aggrMap aggs _ = return $ (aggrMap, aggs)
+    updateCounters [] _ _ aggrMap aggs _ = return (aggrMap, aggs)
     updateCounters (counter : cs) lme (logname, msgname) aggrMap aggs trace = do
         let name = cName counter
             subname = msgname <> "." <> (nameCounter counter) <> "." <> name
@@ -265,14 +237,8 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
         eitherAggregated <- createNupdate fullname value lme aggrMap
         case eitherAggregated of
             Right aggregated -> do
-                now <- getMonotonicTimeNSec
-                let aggregatedX = AggregatedExpanded {
-                                    aeAggregated = aggregated
-                                  , aeResetAfter = Nothing
-                                  , aeLastSent = now
-                                  }
-                    namedAggregated = (subname, aggregated)
-                    updatedMap = HM.alter (const $ Just $ aggregatedX) fullname aggrMap
+                let namedAggregated = (subname, aggregated)
+                    updatedMap = HM.alter (const $ Just $ aggregated) fullname aggrMap
                 updateCounters cs lme (logname, msgname) updatedMap (namedAggregated : aggs) trace
             Left w -> do
                 let trace' = Trace.appendName "updateCounters" trace
@@ -281,12 +247,10 @@ spawnDispatcher conf aggMap aggregationQueue basetrace =
                         <*> pure (LogError w)
                 updateCounters cs lme (logname, msgname) aggrMap aggs trace
 
-    sendAggregated :: Trace.Trace IO a -> LogObject a -> IO ()
-    sendAggregated trace (LogObject loname meta v@(AggregatedMessage _)) = do
-        -- enter the aggregated message into the |Trace|
-        let trace' = Trace.appendName (loname2text loname) trace
-        liftIO $ Trace.traceNamedObject trace' (meta, v)
-    -- ingnore every other message
-    sendAggregated _ _ = return ()
+    sendAggregated :: Trace.Trace IO a -> Text -> Severity -> [(Text, Aggregated)] -> IO ()
+    sendAggregated _trace _loname _sev [] = pure ()
+    sendAggregated trace loname sev v = do
+        meta <- mkLOMeta sev Public
+        traceWith trace (loname, LogObject mempty meta (AggregatedMessage v))
 
 \end{code}

--- a/plugins/backend-editor/src/Cardano/BM/Backend/Editor.lhs
+++ b/plugins/backend-editor/src/Cardano/BM/Backend/Editor.lhs
@@ -140,8 +140,8 @@ instance (ToJSON a, FromJSON a) => IsBackend Editor a where
          -> IO ()
        nullSetup trace mvar nullEditor e = do
          meta <- mkLOMeta Error Public
-         traceWith trace $ LogObject ["#editor", "realizeFrom"] meta $
-           LogError $ "Editor backend disabled due to initialisation error: " <> (pack $ show e)
+         traceWith trace $ ("#editor.realizeFrom", LogObject "#editor.realizeFrom" meta $
+           LogError $ "Editor backend disabled due to initialisation error: " <> (pack $ show e))
          _ <- swapMVar mvar nullEditor
          pure ()
 

--- a/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
@@ -14,7 +14,6 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.HashMap.Strict as HM
 import           Data.ByteString.Builder
 import           Data.ByteString.Char8 (ByteString)
-import           Data.Int (Int64)
 import           Data.Text (Text, replace)
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Text.Read (double)
@@ -36,13 +35,13 @@ spawnPrometheus ekg host port = Async.async $
     simpleHttpServe config site
   where
     config :: Config Snap a
-    config = setPort port . setBind host . setAccessLog log . setErrorLog log $ defaultConfig
-    log = ConfigNoLog
+    config = setPort port . setBind host . setAccessLog lg . setErrorLog lg $ defaultConfig
+    lg = ConfigNoLog
     site :: Snap ()
     site = route [ ("/metrics/", webhandler ekg) ]
     webhandler :: EKG.Server -> Snap ()
-    webhandler ekg = do
-        samples <- liftIO $ sampleAll $ EKG.serverMetricStore ekg
+    webhandler srv = do
+        samples <- liftIO $ sampleAll $ EKG.serverMetricStore srv
         writeLBS . toLazyByteString . renderSamples $ HM.toList samples
         pure ()
     renderSamples :: [(Text, Value)] -> Builder

--- a/plugins/backend-graylog/src/Cardano/BM/Backend/Graylog.lhs
+++ b/plugins/backend-graylog/src/Cardano/BM/Backend/Graylog.lhs
@@ -88,10 +88,10 @@ instance IsEffectuator Graylog a where
                 let traceAgg :: [(Text,Aggregated)] -> IO ()
                     traceAgg [] = return ()
                     traceAgg ((n,AggregatedEWMA agewma):r) = do
-                        enqueue $ LogObject (logname <> [n]) lometa (LogValue "avg" $ avg agewma)
+                        enqueue $ LogObject (logname <> "." <> n) lometa (LogValue "avg" $ avg agewma)
                         traceAgg r
                     traceAgg ((n,AggregatedStats stats):r) = do
-                        let statsname = logname <> [n]
+                        let statsname = logname <> "." <> n
                             qbasestats s' nm = do
                                 enqueue $ LogObject nm lometa (LogValue "mean" (PureD $ meanOfStats s'))
                                 enqueue $ LogObject nm lometa (LogValue "min" $ fmin s')
@@ -99,9 +99,9 @@ instance IsEffectuator Graylog a where
                                 enqueue $ LogObject nm lometa (LogValue "count" $ PureI $ fromIntegral $ fcount s')
                                 enqueue $ LogObject nm lometa (LogValue "stdev" (PureD $ stdevOfStats s'))
                         enqueue $ LogObject statsname lometa (LogValue "last" $ flast stats)
-                        qbasestats (fbasic stats) $ statsname <> ["basic"]
-                        qbasestats (fdelta stats) $ statsname <> ["delta"]
-                        qbasestats (ftimed stats) $ statsname <> ["timed"]
+                        qbasestats (fbasic stats) $ statsname <> ".basic"
+                        qbasestats (fdelta stats) $ statsname <> ".delta"
+                        qbasestats (ftimed stats) $ statsname <> ".timed"
                         traceAgg r
                 traceAgg ags
             (LogObject _ _ (LogMessage _)) -> enqueue item
@@ -237,7 +237,7 @@ mkGelfItem :: ToJSON a => LogObject a -> GelfItem
 mkGelfItem (LogObject loname lometa locontent) = GelfItem {
         version = "1.1",
         host = "hostname",
-        short_message = loname2text loname,
+        short_message = loname,
         full_message = toJSON locontent,
         timestamp = (fromInteger . toInteger $ utc2ns (tstamp lometa) :: Double) / 1000000000,
         level = fromEnum (maxBound @Severity) - fromEnum (severity lometa),

--- a/plugins/backend-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
+++ b/plugins/backend-monitoring/src/Cardano/BM/Backend/Monitoring.lhs
@@ -253,9 +253,8 @@ evalMonitoringAction :: Trace.Trace IO a
                      -> LogObject a
                      -> [(VarName, Measurable)]
                      -> IO MonitorMap
-evalMonitoringAction sbtrace mmap logObj@(LogObject logname0 _ content) variables = do
-    let logname1 = loname2text logname0
-        logname = case content of
+evalMonitoringAction sbtrace mmap logObj@(LogObject logname1 _ content) variables = do
+    let logname = case content of
                     ObserveOpen  _ -> logname1 <> ".open"
                     ObserveDiff  _ -> logname1 <> ".diff"
                     ObserveClose _ -> logname1 <> ".close"
@@ -283,17 +282,17 @@ evalMonitoringAction sbtrace mmap logObj@(LogObject logname0 _ content) variable
     updateEnv :: Environment -> LogObject a -> Environment
     updateEnv env (LogObject loname lometa (ObserveOpen (CounterState counters))) =
         let addenv = HM.fromList $ ("timestamp", Nanoseconds $ utc2ns (tstamp lometa))
-                                 : countersEnvPairs ((loname2text loname) <> ".open") counters
+                                 : countersEnvPairs (loname <> ".open") counters
         in
         HM.union addenv env
     updateEnv env (LogObject loname lometa (ObserveDiff (CounterState counters))) =
         let addenv = HM.fromList $ ("timestamp", Nanoseconds $ utc2ns (tstamp lometa))
-                                 : countersEnvPairs ((loname2text loname) <> ".diff") counters
+                                 : countersEnvPairs (loname <> ".diff") counters
         in
         HM.union addenv env
     updateEnv env (LogObject loname lometa (ObserveClose (CounterState counters))) =
         let addenv = HM.fromList $ ("timestamp", Nanoseconds $ utc2ns (tstamp lometa))
-                                 : countersEnvPairs ((loname2text loname) <> ".close") counters
+                                 : countersEnvPairs (loname <> ".close") counters
         in
         HM.union addenv env
     updateEnv env (LogObject _ lometa (LogValue vn val)) =


### PR DESCRIPTION
description
-----------

- [ ] keeps the context name with the Tracer

the context name is kept with the `Trace`:
```hs
type Trace m a = Tracer m (LoggerName, LogObject a)
```
where it can be extended by calls to `appendName`

on entering the switchboard this name is added to the LogObject:
```hs
mainTraceConditionally :: IsEffectuator eff a => Configuration -> eff a -> Trace IO a
mainTraceConditionally config eff = Tracer $ \(ctxname,item) -> do
    mayItem <- Config.testSubTrace config ctxname item
    case mayItem of
        Just itemF@(LogObject _loname meta _) -> do
            passSevFilter <- Config.testSeverity config ctxname meta
            when passSevFilter $
                -- pass to backend and insert name
                effectuate eff itemF { loName = ctxname }
        Nothing -> pure ()
```

checklist
---------

- [ ] compiles (`cabal new-clean; cabal new-build`)
- [ ] tests run successfully (`cabal new-test`)
- [ ] documentation added and created (`cd docs; nix-shell --run make`)
- [ ] link to an issue
- [ ] link to an epic
- [ ] add estimate points
- [ ] add milestone (the same as the linked issue)
