### PR TITLE
Update default.nix

### DIFF
--- a/scripts/buildkite/default.nix
+++ b/scripts/buildkite/default.nix
@@ -14,7 +14,7 @@ let
   '';
 
   buildTools =
-    [ git nix gnumake stack gnused gnutar coreutils stack-hpc-coveralls systemd ];
+    [ git gzip nix gnumake stack gnused gnutar coreutils stack-hpc-coveralls systemd ];
 
 in
   writeScript "stack-rebuild-wrapped" ''


### PR DESCRIPTION
description
-----------

- [x] buildkite `CI` job misses some dependency

(same as https://github.com/input-output-hk/cardano-ledger/pull/726)

checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
