### PR TITLE
no optimisation in cabal files

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -120,7 +120,7 @@ library
   if flag(performance-test-queue)
     cpp-options:       -DPERFORMANCE_TEST_QUEUE
 
-  ghc-options:         -Wall -Werror -O2
+  ghc-options:         -Wall -Werror
                        -fno-ignore-asserts
 
 test-suite tests


### PR DESCRIPTION
description
-----------

- [x] the cabal file should not define an optimisation flag (by @coot )


checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
