### PR TITLE
CAD-667: support of multiple acceptors.

### DIFF
--- a/examples/acceptor/acceptor.yaml
+++ b/examples/acceptor/acceptor.yaml
@@ -43,11 +43,19 @@ defaultScribes:
 #   contents: "logs/pipe"
 
 traceAcceptAt:
-  tag: RemoteSocket
-  contents:
-    - "127.0.0.1"
-    - "2999"
-  
+  - nodeName: "a"
+    remoteAddr:
+      tag: RemoteSocket
+      contents:
+        - "127.0.0.1"
+        - "2998"
+  - nodeName: "b"
+    remoteAddr:
+      tag: RemoteSocket
+      contents:
+        - "127.0.0.1"
+        - "2999"
+
 # more options which can be passed as key-value pairs:
 options:
   stub:

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -80,7 +80,7 @@ import           Data.Yaml as Yaml
 import           Cardano.BM.Data.AggregatedKind (AggregatedKind(..))
 import           Cardano.BM.Data.BackendKind
 import qualified Cardano.BM.Data.Configuration as R
-import           Cardano.BM.Data.Configuration (RemoteAddr(..))
+import           Cardano.BM.Data.Configuration (RemoteAddr(..), RemoteAddrNamed(..))
 import           Cardano.BM.Data.LogItem (LogObject (..), LoggerName, LOContent (..), severity)
 import           Cardano.BM.Data.MonitoringEval (MEvExpr, MEvPreCond, MEvAction)
 import           Cardano.BM.Data.Output (ScribeDefinition (..), ScribeId,
@@ -149,7 +149,7 @@ data ConfigurationInternal = ConfigurationInternal
     -- host/port to bind Prometheus server at
     , cgForwardTo         :: Maybe RemoteAddr
     -- trace acceptor to forward to
-    , cgAcceptAt          :: Maybe RemoteAddr
+    , cgAcceptAt          :: Maybe [RemoteAddrNamed]
     -- accept remote traces at this address
     , cgPortGUI           :: Int
     -- port for changes at runtime
@@ -329,8 +329,10 @@ setGUIport configuration port =
     modifyMVar_ (getCG configuration) $ \cg ->
         return cg { cgPortGUI = port }
 
-getAcceptAt, getForwardTo :: Configuration -> IO (Maybe RemoteAddr)
-getAcceptAt  = fmap cgAcceptAt  . readMVar . getCG
+getAcceptAt :: Configuration -> IO (Maybe [RemoteAddrNamed])
+getAcceptAt = fmap cgAcceptAt . readMVar . getCG
+
+getForwardTo :: Configuration -> IO (Maybe RemoteAddr)
 getForwardTo = fmap cgForwardTo . readMVar . getCG
 
 setForwardTo :: Configuration -> Maybe RemoteAddr -> IO ()

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -19,6 +19,7 @@ module Cardano.BM.Data.Configuration
   , Port
   , HostPort
   , RemoteAddr (..)
+  , RemoteAddrNamed (..)
   , parseRepresentation
   , readRepresentation
   )
@@ -57,7 +58,7 @@ data Representation = Representation
     , hasPrometheus   :: Maybe HostPort
     , hasGUI          :: Maybe Port
     , traceForwardTo  :: Maybe RemoteAddr
-    , traceAcceptAt   :: Maybe RemoteAddr
+    , traceAcceptAt   :: Maybe [RemoteAddrNamed]
     , options         :: HM.HashMap Text Value
     }
     deriving (Generic, Show, ToJSON, FromJSON)
@@ -66,6 +67,11 @@ data RemoteAddr
   = RemotePipe FilePath
   | RemoteSocket String String
   deriving (Generic, Eq, Show, ToJSON, FromJSON)
+
+data RemoteAddrNamed = RemoteAddrNamed
+  { nodeName   :: Text
+  , remoteAddr :: RemoteAddr
+  } deriving (Generic, Eq, Show, ToJSON, FromJSON)
 
 \end{code}
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -106,7 +106,7 @@ unitConfigurationStaticRepresentation =
             , hasEKG = Just 18321
             , hasPrometheus = Just ("localhost", 12799)
             , traceForwardTo = Just (RemotePipe "to")
-            , traceAcceptAt = Just (RemotePipe "at")
+            , traceAcceptAt = Just [RemoteAddrNamed "a" (RemotePipe "at")]
             , options =
                 HM.fromList [ ("test1", Object (HM.singleton "value" "object1"))
                             , ("test2", Object (HM.singleton "value" "object2")) ]
@@ -132,8 +132,10 @@ unitConfigurationStaticRepresentation =
             , "  tag: RemotePipe"
             , "  contents: to"
             , "traceAcceptAt:"
-            , "  tag: RemotePipe"
-            , "  contents: at"
+            , "- remoteAddr:"
+            , "    tag: RemotePipe"
+            , "    contents: at"
+            , "  nodeName: a"
             , "defaultScribes:"
             , "- - StdoutSK"
             , "  - stdout"
@@ -176,8 +178,10 @@ unitConfigurationParsedRepresentation = do
             , "  tag: RemotePipe"
             , "  contents: to"
             , "traceAcceptAt:"
-            , "  tag: RemotePipe"
-            , "  contents: at"
+            , "- remoteAddr:"
+            , "    tag: RemotePipe"
+            , "    contents: at"
+            , "  nodeName: a"
             , "defaultScribes:"
             , "- - StdoutSK"
             , "  - stdout"
@@ -380,7 +384,7 @@ unitConfigurationParsed = do
         , cgBindAddrPrometheus = Nothing
         , cgPortGUI           = 0
         , cgForwardTo         = Just (RemotePipe "to")
-        , cgAcceptAt          = Just (RemotePipe "at")
+        , cgAcceptAt          = Just [RemoteAddrNamed "a" (RemotePipe "at")]
         }
 
 unitConfigurationExport :: Assertion

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -102,5 +102,7 @@ traceForwardTo:
   contents: to
 
 traceAcceptAt:
-  tag: RemotePipe
-  contents: at
+  - remoteAddr:
+      tag: RemotePipe
+      contents: at
+    nodeName: "a"


### PR DESCRIPTION
description
-----------

- [x] CAD-667 requires an ability to define multiple acceptors in RTView configuration. It will allow assigning every connection a different name prefix.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
