### PR TITLE
CAD 484 | trace forwarding:  named pipes for windows

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,16 +17,20 @@ packages:
 package iohk-monitoring
   tests: True
 
-package contra-tracer
-   -- Currently does not have tests, but set it True in case any are added.
-  tests: True
-  documentation: False
-  haddock-hyperlink-source: True
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/ouroboros-network
+  tag: 7e89518148ebb11d9ee6b973c394a69713961de6
+  --sha256: 06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2
+  subdir: Win32-network
 
-package tracer-transformers
-   -- Currently does not have tests, but set it True in case any are added.
-  tests: True
-  documentation: False
-  haddock-hyperlink-source: True
+constraints:
+  ip < 1.5,
+  hedgehog >= 1.0,
+  bimap >= 0.4.0,
+  libsystemd-journal >= 1.4.4
 
-reorder-goals: True
+allow-newer: katip:Win32
+
+package comonad
+  flags: -test-doctests

--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 7e89518148ebb11d9ee6b973c394a69713961de6
-  --sha256: 06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2
+  tag: 5837c635877c11e1bf6c058c8307733c631dc98b
+  --sha256: 1cw1mxwszal0f38m236bfcwdwq2ap1klkqdilv8r836al71djz41
   subdir: Win32-network
 
 constraints:

--- a/examples/acceptor/Main.hs
+++ b/examples/acceptor/Main.hs
@@ -8,6 +8,7 @@ import           Data.Text (Text)
 import           Cardano.BM.Backend.TraceAcceptor
 import           Cardano.BM.Configuration
 import qualified Cardano.BM.Configuration as Config
+import           Cardano.BM.IOManager
 import           Cardano.BM.Plugin (loadPlugin)
 import qualified Cardano.BM.Setup as Setup
 import           Cardano.BM.Trace
@@ -36,9 +37,10 @@ main = do
     Just _ra -> do
       (tr :: Trace IO Text, sb) <- Setup.setupTrace_ config "cardano"
       let tr' = Trace.appendName "acceptor" tr
-      Cardano.BM.Backend.TraceAcceptor.plugin config tr' sb
-        >>= loadPlugin sb
-      forever $ threadDelay 1000000
+      withIOManager $ \iomgr -> do
+        Cardano.BM.Backend.TraceAcceptor.plugin iomgr config tr' sb
+          >>= loadPlugin sb
+        forever $ threadDelay 1000000
     Nothing ->
       putStrLn $ "Trace acceptor not enabled in config: " <> cConfig cli
  where

--- a/examples/acceptor/acceptor.yaml
+++ b/examples/acceptor/acceptor.yaml
@@ -38,17 +38,12 @@ defaultScribes:
   - - FileSK
     - "logs/acceptor.log"
 
-# traceAcceptAt:
-#   tag: RemotePipe
-#   contents: "logs/pipe"
-
 traceAcceptAt:
   - nodeName: "a"
     remoteAddr:
-      tag: RemoteSocket
-      contents:
-        - "127.0.0.1"
-        - "2998"
+      tag: RemotePipe
+      contents: "logs/pipe"
+      # contents: "\\\\.\\pipe\\acceptor" # Windows
   - nodeName: "b"
     remoteAddr:
       tag: RemoteSocket

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -205,6 +205,7 @@ prepare_configuration = do
     CM.setGUIport c 13790
 
     -- CM.setForwardTo c (Just $ RemotePipe "logs/pipe")
+    -- CM.setForwardTo c (Just $ RemotePipe "\\\\.\\pipe\\acceptor") -- Windows
     CM.setForwardTo c (Just $ RemoteSocket "127.0.0.1" "2999")
 
     CM.setMonitors c $ HM.fromList

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -62,6 +62,10 @@ library
                        Cardano.BM.Trace
                        Cardano.BM.Tracer
 
+                       -- shamelessly stolen from ouroboros-network-framework
+                       Cardano.BM.IOManager
+                       Cardano.BM.Snocket
+
   if !flag(disable-observables)
     exposed-modules:   Cardano.BM.Observer.Monadic
                        Cardano.BM.Observer.STM
@@ -107,6 +111,7 @@ library
                        transformers,
                        unordered-containers,
                        vector,
+                       Win32-network,
                        yaml, libyaml
 
   if os(windows)

--- a/iohk-monitoring/src/Cardano/BM/IOManager.hs
+++ b/iohk-monitoring/src/Cardano/BM/IOManager.hs
@@ -1,5 +1,5 @@
 --
--- Stolen from 'ouroboros-network-framework'
+-- copied from https://github.com/input-output-hk/ouroboros-network
 --
 {-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}

--- a/iohk-monitoring/src/Cardano/BM/IOManager.hs
+++ b/iohk-monitoring/src/Cardano/BM/IOManager.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- | A shim layer for `Win32-network`'s `IOManager`
+--
+module Cardano.BM.IOManager
+  ( module X
+  ) where
+
+import System.IOManager as X

--- a/iohk-monitoring/src/Cardano/BM/IOManager.hs
+++ b/iohk-monitoring/src/Cardano/BM/IOManager.hs
@@ -1,3 +1,6 @@
+--
+-- Stolen from 'ouroboros-network-framework'
+--
 {-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}
 

--- a/iohk-monitoring/src/Cardano/BM/Snocket.hs
+++ b/iohk-monitoring/src/Cardano/BM/Snocket.hs
@@ -1,5 +1,5 @@
 --
--- Stolen from 'ouroboros-network-framework'
+-- copied from https://github.com/input-output-hk/ouroboros-network
 --
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE GADTs               #-}

--- a/iohk-monitoring/src/Cardano/BM/Snocket.hs
+++ b/iohk-monitoring/src/Cardano/BM/Snocket.hs
@@ -1,0 +1,418 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.BM.Snocket
+  ( -- * Snocket Interface
+    Accept (..)
+  , fmapAccept
+  , mkListeningSocket
+  , AddressFamily (..)
+  , Snocket (..)
+    -- ** Socket based Snocktes
+  , SocketSnocket
+  , socketSnocket
+    -- ** Local Snockets
+    -- Using unix sockets (posix) or named pipes (windows)
+    --
+  , LocalSnocket
+  , localSnocket
+  , LocalAddress (..)
+  , LocalFD
+  , localAddressFromPath
+  ) where
+
+import           Control.Exception
+import           Control.Monad (when)
+import           Network.Socket ( Family (AF_UNIX)
+                                , Socket
+                                , SockAddr (..)
+                                )
+import qualified Network.Socket as Socket
+#if defined(mingw32_HOST_OS)
+import           Data.Bits
+import qualified System.Win32            as Win32
+import qualified System.Win32.NamedPipes as Win32
+import qualified System.Win32.Async      as Win32.Async
+
+#endif
+
+import           Cardano.BM.IOManager
+
+
+-- | Named pipes and Berkeley sockets have different API when accepting
+-- a connection.  For named pipes the file descriptor created by 'createNamedPipe' is
+-- supposed to be used for the first connected client.  Named pipe accept loop
+-- looks this way:
+--
+-- > acceptLoop k = do
+-- >   h <- createNamedPipe name
+-- >   connectNamedPipe h
+-- >   -- h is now in connected state
+-- >   forkIO (k h)
+-- >   acceptLoop k
+--
+-- For Berkeley sockets equivalent loop starts by creating a socket
+-- which accepts connections and accept returns a new socket in connected
+-- state
+--
+-- > acceptLoop k = do
+-- >     s <- socket ...
+-- >     bind s address
+-- >     listen s
+-- >     loop s
+-- >   where
+-- >     loop s = do
+-- >       (s' , _addr') <- accept s
+-- >       -- s' is in connected state
+-- >       forkIO (k s')
+-- >       loop s
+--
+-- To make common API for both we use a recursive type 'Accept', see
+-- 'berkeleyAccept' below.  Creation of a socket / named pipe is part of
+-- 'Snocket', but this means we need to have different recursion step for named
+-- pipe & sockets.  For sockets its recursion step will always return 'accept'
+-- syscall; for named pipes the first callback will reuse the file descriptor
+-- created by 'open' and only subsequent calls will create a new file
+-- descriptor by `createNamedPipe`, see 'namedPipeSnocket'.
+--
+newtype Accept addr fd = Accept
+  { runAccept :: IO (fd, addr, Accept addr fd)
+  }
+
+
+-- | Arguments of 'Accept' are in the wrong order.
+--
+-- TODO: this can be fixed later.
+--
+fmapAccept :: (addr -> addr') -> Accept addr fd -> Accept addr' fd
+fmapAccept f ac = Accept $ g <$> runAccept ac
+  where
+    g (fd, addr, next) = (fd, f addr, fmapAccept f next)
+
+
+mkListeningSocket
+    :: Snocket IO fd addr
+    -> Maybe addr
+    -> AddressFamily addr
+    -> IO fd
+mkListeningSocket sn addr family_ = do
+    sd <- open sn family_
+
+    case addr of
+      Nothing -> pure ()
+      Just addr_ -> do
+        bind sn sd addr_
+        listen sn sd
+    pure sd
+
+-- | BSD accept loop.
+--
+berkeleyAccept :: IOManager
+               -> Socket
+               -> Accept SockAddr Socket
+berkeleyAccept ioManager sock = go
+    where
+      go = Accept $ do
+        (sock', addr') <-
+#if !defined(mingw32_HOST_OS)
+          Socket.accept sock
+#else
+          Win32.Async.accept sock
+#endif
+        associateWithIOManager ioManager (Right sock')
+          `catch` \(e :: IOException) -> do
+            Socket.close sock'
+            throwIO e
+          `catch` \(SomeAsyncException _) -> do
+            Socket.close sock'
+            throwIO e
+        return (sock', addr', go)
+
+-- | Local address, on Unix is associated with `Socket.AF_UNIX` family, on
+--
+-- Windows with `named-pipes`.
+--
+newtype LocalAddress = LocalAddress { getFilePath :: FilePath }
+  deriving (Show, Eq, Ord)
+
+
+-- | We support either sockets or named pipes.
+--
+data AddressFamily addr where
+
+    SocketFamily :: !Socket.Family
+                 -> AddressFamily Socket.SockAddr
+
+    LocalFamily  :: AddressFamily LocalAddress
+
+instance Eq (AddressFamily addr) where
+    SocketFamily fam0 == SocketFamily fam1 = fam0 == fam1
+    LocalFamily       == LocalFamily       = True
+
+instance Show (AddressFamily addr) where
+    show (SocketFamily fam) = show fam
+    show LocalFamily        = "LocalFamily"
+
+-- | Abstract communication interface that can be used by more than
+-- 'Socket'.  Snockets are polymorphic over monad which is used, this feature
+-- is useful for testing and/or simulations.
+--
+data Snocket m fd addr = Snocket {
+    getLocalAddr  :: fd -> m addr
+  , getRemoteAddr :: fd -> m addr
+
+  , addrFamily :: addr -> AddressFamily addr
+
+  -- | Open a file descriptor  (socket / namedPipe).  For named pipes this is
+  -- using 'CreateNamedPipe' syscall, for Berkeley sockets 'socket' is used..
+  --
+  , open          :: AddressFamily addr -> m fd
+
+    -- | A way to create 'fd' to pass to 'connect'.  For named pipes it will
+    -- use 'CreateFile' syscall.  For Berkeley sockets this the same as 'open'.
+    --
+    -- For named pipes we need full 'addr' rather than just address family as
+    -- it is for sockets.
+    --
+  , openToConnect :: addr ->  m fd
+
+    -- | `connect` is only needed for Berkeley sockets, for named pipes this is
+    -- no-op.
+    --
+  , connect       :: fd -> addr -> m ()
+  , bind          :: fd -> addr -> m ()
+  , listen        :: fd -> m ()
+
+  , accept        :: fd -> Accept addr fd
+
+  , close         :: fd -> m ()
+
+  }
+
+
+--
+-- Socket based Snockets
+--
+
+
+socketAddrFamily
+    :: Socket.SockAddr
+    -> AddressFamily Socket.SockAddr
+socketAddrFamily (Socket.SockAddrInet  _ _    ) = SocketFamily Socket.AF_INET
+socketAddrFamily (Socket.SockAddrInet6 _ _ _ _) = SocketFamily Socket.AF_INET6
+socketAddrFamily (Socket.SockAddrUnix _       ) = SocketFamily Socket.AF_UNIX
+
+
+type SocketSnocket = Snocket IO Socket SockAddr
+
+
+-- | Create a 'Snocket' for the given 'Socket.Family'. In the 'bind' method set
+-- 'Socket.ReuseAddr` and 'Socket.ReusePort'.
+--
+socketSnocket
+  :: IOManager
+  -- ^ 'IOManager' interface.  We use it when we create a new socket and when we
+  -- accept a connection.
+  --
+  -- Though it could be used in `open`, but that is going to be used in
+  -- a bracket so it's better to keep it simple.
+  --
+  -> SocketSnocket
+socketSnocket ioManager = Snocket {
+      getLocalAddr   = Socket.getSocketName
+    , getRemoteAddr  = Socket.getPeerName
+    , addrFamily     = socketAddrFamily
+    , open           = openSocket
+    , openToConnect  = \addr -> openSocket (socketAddrFamily addr)
+    , connect        = \s a -> do
+#if !defined(mingw32_HOST_OS)
+        Socket.connect s a
+#else
+        Win32.Async.connect s a
+#endif
+    , bind = \sd addr -> do
+        let SocketFamily fml = socketAddrFamily addr
+        when (fml == Socket.AF_INET ||
+              fml == Socket.AF_INET6) $ do
+          Socket.setSocketOption sd Socket.ReuseAddr 1
+#if !defined(mingw32_HOST_OS)
+          -- not supported on Windows 10
+          Socket.setSocketOption sd Socket.ReusePort 1
+#endif
+        when (fml == Socket.AF_INET6)
+          -- An AF_INET6 socket can be used to talk to both IPv4 and IPv6 end points, and
+          -- it is enabled by default on some systems. Disabled here since we run a separate
+          -- IPv4 server instance if configured to use IPv4.
+          $ Socket.setSocketOption sd Socket.IPv6Only 1
+
+        Socket.bind sd addr
+    , listen   = \s -> Socket.listen s 8
+    , accept   = berkeleyAccept ioManager
+    , close    = Socket.close
+    }
+  where
+
+    openSocket :: AddressFamily SockAddr -> IO Socket
+    openSocket (SocketFamily family_) = do
+      sd <- Socket.socket family_ Socket.Stream Socket.defaultProtocol
+      associateWithIOManager ioManager (Right sd)
+        -- open is designed to be used in `bracket`, and thus it's called with
+        -- async exceptions masked.  The 'associteWithIOCP' is a blocking
+        -- operation and thus it may throw.
+        `catch` \(e :: IOException) -> do
+          Socket.close sd
+          throwIO e
+        `catch` \(SomeAsyncException _) -> do
+          Socket.close sd
+          throwIO e
+      return sd
+
+
+
+--
+-- NamedPipes based Snocket
+--
+
+
+#if defined(mingw32_HOST_OS)
+type HANDLESnocket = Snocket IO Win32.HANDLE LocalAddress
+
+-- | Create a Windows Named Pipe Snocket.
+--
+namedPipeSnocket
+  :: IOManager
+  -> FilePath
+  -> HANDLESnocket
+namedPipeSnocket ioManager path = Snocket {
+      getLocalAddr  = \_ -> return localAddress
+    , getRemoteAddr = \_ -> return localAddress
+    , addrFamily  = \_ -> LocalFamily
+
+    , open = \_addrFamily -> do
+        hpipe <- Win32.createNamedPipe
+                   path
+                   (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
+                   (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
+                   Win32.pIPE_UNLIMITED_INSTANCES
+                   65536   -- outbound pipe size
+                   16384   -- inbound pipe size
+                   0       -- default timeout
+                   Nothing -- default security
+        associateWithIOManager ioManager (Left hpipe)
+          `catch` \(e :: IOException) -> do
+            Win32.closeHandle hpipe
+            throwIO e
+          `catch` \(SomeAsyncException _) -> do
+            Win32.closeHandle hpipe
+            throwIO e
+        pure hpipe
+
+    -- To connect, simply create a file whose name is the named pipe name.
+    , openToConnect  = \(LocalAddress pipeName) -> do
+        hpipe <- Win32.connect pipeName
+                   (Win32.gENERIC_READ .|. Win32.gENERIC_WRITE )
+                   Win32.fILE_SHARE_NONE
+                   Nothing
+                   Win32.oPEN_EXISTING
+                   Win32.fILE_FLAG_OVERLAPPED
+                   Nothing
+        associateWithIOManager ioManager (Left hpipe)
+          `catch` \(e :: IOException) -> do
+            Win32.closeHandle hpipe
+            throwIO e
+          `catch` \(SomeAsyncException _) -> do
+            Win32.closeHandle hpipe
+            throwIO e
+        return hpipe
+    , connect  = \_ _ -> pure ()
+
+    -- Bind and listen are no-op.
+    , bind     = \_ _ -> pure ()
+    , listen   = \_ -> pure ()
+
+    , accept   = \hpipe -> Accept $ do
+          Win32.Async.connectNamedPipe hpipe
+          return (hpipe, localAddress, acceptNext)
+
+    , close    = Win32.closeHandle
+    }
+  where
+    localAddress :: LocalAddress
+    localAddress = LocalAddress path
+
+    acceptNext :: Accept LocalAddress Win32.HANDLE
+    acceptNext = Accept $ do
+      hpipe <- Win32.createNamedPipe
+                 path
+                 (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
+                 (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
+                 Win32.pIPE_UNLIMITED_INSTANCES
+                 65536   -- outbound pipe size
+                 16384   -- inbound pipe size
+                 0       -- default timeout
+                 Nothing -- default security
+              `catch` \(e :: IOException) -> do
+                 putStrLn $ "accept: " ++ show e
+                 throwIO e
+      associateWithIOManager ioManager (Left hpipe)
+      Win32.Async.connectNamedPipe hpipe
+      return (hpipe, localAddress, acceptNext)
+#endif
+
+
+--
+-- Windows/POSIX type aliases
+--
+
+localSnocket :: IOManager -> FilePath -> LocalSnocket
+-- | System dependent LocalSnocket type
+#if defined(mingw32_HOST_OS)
+type LocalSnocket = HANDLESnocket
+type LocalFD      = Win32.HANDLE
+
+localSnocket = namedPipeSnocket
+#else
+type LocalSnocket = Snocket IO Socket LocalAddress
+type LocalFD      = Socket
+
+localSnocket ioManager _ = Snocket {
+      getLocalAddr  = fmap toLocalAddress . Socket.getSocketName
+    , getRemoteAddr = fmap toLocalAddress . Socket.getPeerName
+    , addrFamily    = const LocalFamily
+    , connect       = \s addr -> do
+        Socket.connect s (fromLocalAddress addr)
+    , bind          = \fd addr -> Socket.bind fd (fromLocalAddress addr)
+    , listen        = flip Socket.listen 1
+    , accept        = fmapAccept toLocalAddress . (berkeleyAccept ioManager)
+    , open          = openSocket
+    , openToConnect = \_addr -> openSocket LocalFamily
+    , close         = Socket.close
+    }
+  where
+    toLocalAddress :: SockAddr -> LocalAddress
+    toLocalAddress (SockAddrUnix path) = LocalAddress path
+    toLocalAddress _                   = error "localSnocket.toLocalAddr: impossible happend"
+
+    fromLocalAddress :: LocalAddress -> SockAddr
+    fromLocalAddress = SockAddrUnix . getFilePath
+
+    openSocket :: AddressFamily LocalAddress -> IO Socket
+    openSocket LocalFamily = do
+      sd <- Socket.socket AF_UNIX Socket.Stream Socket.defaultProtocol
+      associateWithIOManager ioManager (Right sd)
+        -- open is designed to be used in `bracket`, and thus it's called with
+        -- async exceptions masked.  The 'associteWithIOManager' is a blocking
+        -- operation and thus it may throw.
+        `catch` \(e :: IOException) -> do
+          Socket.close sd
+          throwIO e
+        `catch` \(SomeAsyncException _) -> do
+          Socket.close sd
+          throwIO e
+      return sd
+#endif
+
+localAddressFromPath :: FilePath -> LocalAddress
+localAddressFromPath = LocalAddress

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -29,7 +29,7 @@ let
       (pkgs: _: with pkgs; {
 
         # commonLib: mix pkgs.lib with iohk-nix utils and our own:
-        commonLib = lib // iohkNix
+        commonLib = lib // iohkNix // iohkNix.cardanoLib
           // import ./util.nix { inherit haskell-nix; }
           # also expose our sources and overlays
           // { inherit overlays sources; };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,17 +22,5 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/iohk-nix/archive/ca80aeb33e8ca854dca77c1098a90136b9dabf2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "niv": {
-        "branch": "iohk",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/nmattia/niv",
-        "owner": "input-output-hk",
-        "repo": "niv",
-        "rev": "89da7b2e7ae0779fd351618fc74df1b1da5e6214",
-        "sha256": "0jn88ahv6mycxdkzihy1v0dz2110q0d42q4ggyj68l2lyba6y0yy",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/niv/archive/89da7b2e7ae0779fd351618fc74df1b1da5e6214.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "480177ce8308d7baa9e060c4163f158d8584c4e2",
-        "sha256": "00mcb5r7c1w52jbiig0qrjhqfyrlrlq67jv0w5n1ll8l6zic6sss",
+        "rev": "98ac006e995d310c9329787bd93f6c3384174713",
+        "sha256": "01v80m0m59csjacbax8z0k2mlx6vww0wh5qnmgcwdq9zfa5d3g81",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/480177ce8308d7baa9e060c4163f158d8584c4e2.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/98ac006e995d310c9329787bd93f6c3384174713.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,22 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "6ce1a519cc139781dfd4d68760d8596f0a6e4e84",
-        "sha256": "058lfjbinjn7ra8h5mpy7l191z2pzyqihrsw0a6kmy46v9xlm7gi",
+        "rev": "ca80aeb33e8ca854dca77c1098a90136b9dabf2e",
+        "sha256": "0sp9v7l68xq1kg4862pcpjji918lgb6jlak4p6lpv2k4h93dypv2",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/6ce1a519cc139781dfd4d68760d8596f0a6e4e84.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/ca80aeb33e8ca854dca77c1098a90136b9dabf2e.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "niv": {
+        "branch": "iohk",
+        "description": "Easy dependency management for Nix projects",
+        "homepage": "https://github.com/nmattia/niv",
+        "owner": "input-output-hk",
+        "repo": "niv",
+        "rev": "89da7b2e7ae0779fd351618fc74df1b1da5e6214",
+        "sha256": "0jn88ahv6mycxdkzihy1v0dz2110q0d42q4ggyj68l2lyba6y0yy",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/niv/archive/89da7b2e7ae0779fd351618fc74df1b1da5e6214.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,16 +1,8 @@
-# This is the derivation used by "stack --nix".
-# It provides the system dependencies required for a stack build.
+
 with import ./. {};
 
 haskell.lib.buildStackProject {
   name = "stack-env";
-  ghc = (import ../shell.nix { inherit pkgs; }).ghc.baseGhc;
-
-  buildInputs =
-    # Development libraries which may be necessary for the build.
-    # Add remove libraries as necessary
-    [ zlib openssl git systemd ];
-
-  phases = ["nobuildPhase"];
-  nobuildPhase = "mkdir -p $out";
+  buildInputs = with pkgs; [ zlib openssl gmp libffi git systemd haskellPackages.happy ];
+  ghc = (import ../shell.nix {inherit pkgs;}).ghc;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,20 @@ let
 
     # If shellFor local packages selection is wrong,
     # then list all local packages then include source-repository-package that cabal complains about:
-    #packages = ps: with ps; [
-    #];
+    packages = ps: with ps; [
+      contra-tracer
+      iohk-monitoring
+      lobemo-backend-aggregation
+      lobemo-backend-editor
+      lobemo-backend-ekg
+      lobemo-backend-graylog
+      lobemo-backend-monitoring
+      lobemo-backend-trace-acceptor
+      lobemo-backend-trace-forwarder
+      lobemo-scribe-systemd
+      lobemo-examples
+      tracer-transformers
+    ];
 
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 resolver: lts-13.26
 compiler: ghc-8.6.5
+
 packages:
   - contra-tracer
   - tracer-transformers
@@ -14,10 +15,17 @@ packages:
   - plugins/scribe-systemd
   - examples
 
+allow-newer: true
+
 extra-deps:
-  - time-units-1.0.0
-  - libsystemd-journal-1.4.4
-  - katip-0.8.3.0
+  - network-3.1.1.1
+  - snap-core-1.0.4.1
+  - snap-server-1.1.1.1
+
+  - git: https://github.com/input-output-hk/ouroboros-network
+    commit: 7e89518148ebb11d9ee6b973c394a69713961de6
+    subdirs:
+        - Win32-network
 
 nix:
-  shell-file: nix/stack-shell.nix
+    shell-file: nix/stack-shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,9 @@ extra-deps:
   - snap-core-1.0.4.1
   - snap-server-1.1.1.1
 
+  - time-units-1.0.0
+  - katip-0.8.3.0
+
   - git: https://github.com/input-output-hk/ouroboros-network
     commit: 5837c635877c11e1bf6c058c8307733c631dc98b
     subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
   - snap-server-1.1.1.1
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 7e89518148ebb11d9ee6b973c394a69713961de6
+    commit: 5837c635877c11e1bf6c058c8307733c631dc98b
     subdirs:
         - Win32-network
 


### PR DESCRIPTION
1. Copy over the `Ouroboros.Network.Snocket` module from `ouroboros-network-framework`
2. Reimplement the forwarder and acceptor in terms of snockets, thereby automagically gaining named pipe support on Windows.
3. Syncs all dependency versions to that of `cardano-node`.
4. Fix evaluation errors in Nix code.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
