### PR TITLE
Fix ghc provided by stack-shell.nix

### DIFF
--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -4,5 +4,5 @@ with import ./. {};
 haskell.lib.buildStackProject {
   name = "stack-env";
   buildInputs = with pkgs; [ zlib openssl gmp libffi git systemd haskellPackages.happy ];
-  ghc = (import ../shell.nix {inherit pkgs;}).ghc;
+  ghc = (import ../shell.nix {inherit pkgs;}).ghc.baseGhc;
 }


### PR DESCRIPTION
Should solve the
"I don't know how to install GHC on your system configuration, please install manually"
error.
