### PR TITLE
CAD-876 minimum severity filter in TraceForwarder

### DIFF
--- a/examples/acceptor/acceptor.yaml
+++ b/examples/acceptor/acceptor.yaml
@@ -49,7 +49,7 @@ traceAcceptAt:
       tag: RemoteSocket
       contents:
         - "127.0.0.1"
-        - "2999"
+        - "42999"
 
 # more options which can be passed as key-value pairs:
 options:

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -53,6 +53,7 @@ import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.Aggregated (Measurable (..))
 import           Cardano.BM.Data.AggregatedKind
 import           Cardano.BM.Data.BackendKind
+import           Cardano.BM.Data.Configuration (RemoteAddr(..))
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MonitoringEval
 import           Cardano.BM.Data.Output
@@ -218,7 +219,8 @@ prepare_configuration = do
 
     -- CM.setForwardTo c (Just $ RemotePipe "logs/pipe")
     -- CM.setForwardTo c (Just $ RemotePipe "\\\\.\\pipe\\acceptor") -- on Windows
-    -- CM.setForwardTo c (Just $ RemoteSocket "127.0.0.1" "2999")
+    CM.setForwardTo c (Just $ RemoteSocket "127.0.0.1" "42999")
+    CM.setTextOption c "forwarderMinSeverity" "Warning"  -- sets min severity filter in forwarder
 
     CM.setMonitors c $ HM.fromList
         [ ( "complex.monitoring"
@@ -430,7 +432,7 @@ main = do
       >>= loadPlugin sb
     forwardTo <- CM.getForwardTo c
     when (isJust forwardTo) $
-      Cardano.BM.Backend.TraceForwarder.plugin c tr sb
+      Cardano.BM.Backend.TraceForwarder.plugin c tr sb "forwarderMinSeverity"
         >>= loadPlugin sb
     Cardano.BM.Backend.Aggregation.plugin c tr sb
       >>= loadPlugin sb

--- a/plugins/backend-trace-acceptor/src/Cardano/BM/Backend/TraceAcceptor.lhs
+++ b/plugins/backend-trace-acceptor/src/Cardano/BM/Backend/TraceAcceptor.lhs
@@ -11,7 +11,6 @@
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecursiveDo           #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# OPTIONS_GHC -Wextra            #-}

--- a/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -2,7 +2,6 @@
 \subsection{Cardano.BM.Backend.TraceForwarder}
 \label{module:Cardano.BM.Backend.TraceForwarder}
 
-
 %if style == newcode
 \begin{code}
 {-# LANGUAGE CPP                   #-}
@@ -23,20 +22,25 @@ module Cardano.BM.Backend.TraceForwarder
     ) where
 
 import           Control.Exception
+import           Control.Monad (when)
 import           Data.Aeson (FromJSON, ToJSON, encode)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BL
+import           Data.Maybe (fromMaybe)
+import           Data.Text (Text, unpack)
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Typeable (Typeable)
 
 import qualified Network.Socket as Socket
 import           System.IO (Handle, IOMode (..), hClose)
+import           Text.Read (readMaybe)
 
 import           Cardano.BM.Configuration
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.Configuration (RemoteAddr(..))
 import           Cardano.BM.Data.LogItem (LOMeta (..), LogObject (..))
+import           Cardano.BM.Data.Severity (Severity (..))
 import           Cardano.BM.IOManager
 import           Cardano.BM.Plugin
 import qualified Cardano.BM.Snocket as Snocket
@@ -50,14 +54,22 @@ different process (running a |TraceAcceptor| backend), by means of
 either a pipe or a socket.
 
 Note that if the connection to the trace acceptor is broken,
-the application is terminated.
+the application is terminated. (TODO)
 
+The |TraceForwarder| is looking up a minimum |Severity| in the options
+section of the configuration. This filters out all messages that have not at
+least the |Severity|.
 \subsubsection{Plugin definition}
 \begin{code}
-plugin :: (IsEffectuator s a, ToJSON a, FromJSON a)
-       => Configuration -> Trace.Trace IO a -> s a -> IO (Plugin a)
-plugin config _trace _sb = do
-    be :: Cardano.BM.Backend.TraceForwarder.TraceForwarder a <- realize config
+plugin :: forall a s . (IsEffectuator s a, ToJSON a, FromJSON a)
+       => Configuration -> Trace.Trace IO a -> s a -> Text -> IO (Plugin a)
+plugin config _trace _sb tfid = do
+    be0 :: Cardano.BM.Backend.TraceForwarder.TraceForwarder a <- realize config
+    opts <- getTextOption config tfid
+    let minsev = case opts of
+                   Nothing -> Debug
+                   Just sevtext -> fromMaybe Debug (readMaybe $ unpack sevtext)
+    let be = be0 { tfFilter = minsev }
     return $ BackendPlugin
                (MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be })
                (bekind be)
@@ -70,6 +82,7 @@ Contains the handler to the pipe or to the socket.
 data TraceForwarder a = TraceForwarder
   { tfWrite   :: BSC.ByteString -> IO ()
   , tfClose   :: IO ()
+  , tfFilter  :: Severity
   }
 
 \end{code}
@@ -79,10 +92,12 @@ Every |LogObject| before being written to the given handler is converted to
 |ByteString| through its |JSON| represantation.
 \begin{code}
 instance (ToJSON a) => IsEffectuator TraceForwarder a where
-    effectuate tf lo = do
-        tfWrite tf $ encodeUtf8 (hostname $ loMeta lo)
-        tfWrite tf bs
+    effectuate tf lo =
+        when (severity meta >= tfFilter tf) $ do
+          tfWrite tf $ encodeUtf8 (hostname meta)
+          tfWrite tf bs
       where
+        meta = loMeta lo
         (_, bs) = jsonToBS lo
 
         jsonToBS :: ToJSON b => b -> (Int, BS.ByteString)
@@ -112,6 +127,7 @@ instance (FromJSON a, ToJSON a) => IsBackend TraceForwarder a where
           pure TraceForwarder
             { tfClose = hClose h
             , tfWrite = \bs -> BSC.hPutStrLn h $! bs
+            , tfFilter = Debug  -- default
             }
 
     unrealize = tfClose
@@ -122,7 +138,7 @@ handleError ctor = flip catch $ \(e :: IOException) -> throwIO . ctor . show $ e
 connectForwarder :: IOManager -> RemoteAddr -> IO Handle
 connectForwarder iomgr (RemotePipe pipePath) = do
   let sn = Snocket.localSnocket iomgr pipePath
-  Snocket.localFDToHandle =<< (doConnect sn $ Snocket.localAddressFromPath pipePath)
+  Snocket.localFDToHandle =<< doConnect sn (Snocket.localAddressFromPath pipePath)
 connectForwarder iomgr (RemoteSocket host port) = do
   let sn = Snocket.socketSnocket iomgr
   addrs <- Socket.getAddrInfo Nothing (Just host) (Just port)


### PR DESCRIPTION

description
-----------

- [x] TraceForwarder with a minimum severity filter

testing
-------
run in a first terminal:
`cabal exec example-acceptor -- --config examples/acceptor/acceptor.yaml`

and in a second:
`cabal exec example-complex`

the second should forward messages with severity >= Warning to the acceptor which shows them in the terminal.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
