### PR TITLE
CAD-792:  non-API-breaking efficiency optimisations

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -197,8 +197,8 @@ Payload of a |LogObject|:
 data LOContent a = LogMessage a
                  | LogError !Text
                  | LogValue !Text !Measurable
-                 | LogStructured !Object
                  | LogStructuredText Object Text
+                 | LogStructured Object
                  | ObserveOpen !CounterState
                  | ObserveDiff !CounterState
                  | ObserveClose !CounterState

--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -341,8 +341,7 @@ trStructured :: (ToObject b, MonadIO m, HasPrivacyAnnotation b, HasSeverityAnnot
 trStructured verb tr = Tracer $ \arg ->
  let
    obj = toObject verb arg
-   tracer = if obj == emptyObject then nullTracer else tr
- in traceWith tracer =<< do
+ in traceWith tr =<< do
           meta <- mkLOMeta (getSeverityAnnotation arg) (getPrivacyAnnotation arg)
           return ( mempty
                  , LogObject mempty meta (LogStructuredText obj (T.pack $ show $ obj))
@@ -365,8 +364,7 @@ trStructuredText :: ( ToObject b, MonadIO m, HasTextFormatter b
 trStructuredText verb tr = Tracer $ \arg ->
  let
    obj = toObject verb arg
-   tracer = if obj == emptyObject then nullTracer else tr
- in traceWith tracer =<< do
+ in traceWith tr =<< do
           meta <- mkLOMeta (getSeverityAnnotation arg) (getPrivacyAnnotation arg)
           return ( mempty
                  , LogObject mempty meta (LogStructuredText obj (formatText arg obj))


### PR DESCRIPTION
1. CAD-792:  make LogStructured lazy as well
1. CAD-792 trStructured:  don't test the toObject for emptiness
1. CAD-810:  generalised caching, with toggles for cache disabling


checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
