### PR TITLE
CAD-875: Fail-safe mode for trace forwarder.

### DIFF
--- a/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -23,6 +23,9 @@ module Cardano.BM.Backend.TraceForwarder
 
 import           Control.Exception
 import           Control.Monad (when)
+import           Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import           Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar)
 import           Data.Aeson (FromJSON, ToJSON, encode)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
@@ -53,9 +56,6 @@ import qualified Cardano.BM.Trace as Trace
 different process (running a |TraceAcceptor| backend), by means of
 either a pipe or a socket.
 
-Note that if the connection to the trace acceptor is broken,
-the application is terminated. (TODO)
-
 The |TraceForwarder| is looking up a minimum |Severity| in the options
 section of the configuration. This filters out all messages that have not at
 least the |Severity|.
@@ -64,12 +64,18 @@ least the |Severity|.
 plugin :: forall a s . (IsEffectuator s a, ToJSON a, FromJSON a)
        => Configuration -> Trace.Trace IO a -> s a -> Text -> IO (Plugin a)
 plugin config _trace _sb tfid = do
-    be0 :: Cardano.BM.Backend.TraceForwarder.TraceForwarder a <- realize config
     opts <- getTextOption config tfid
     let minsev = case opts of
                    Nothing -> Debug
                    Just sevtext -> fromMaybe Debug (readMaybe $ unpack sevtext)
-    let be = be0 { tfFilter = minsev }
+    be :: Cardano.BM.Backend.TraceForwarder.TraceForwarder a <- realize config
+    -- Currently there's no connection with TraceAcceptor yet, the first attempt to establish it...
+    connectorThr <- Async.async $ establishConnection (getTF be)
+    modifyMVar_ (getTF be) $ \initialBE ->
+      return $ initialBE
+                 { tfFilter    = minsev
+                 , tfConnector = Just connectorThr
+                 }
     return $ BackendPlugin
                (MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be })
                (bekind be)
@@ -79,12 +85,17 @@ plugin config _trace _sb tfid = do
 \subsubsection{Structure of TraceForwarder}\label{code:TraceForwarder}\index{TraceForwarder}
 Contains the handler to the pipe or to the socket.
 \begin{code}
-data TraceForwarder a = TraceForwarder
-  { tfWrite   :: BSC.ByteString -> IO ()
-  , tfClose   :: IO ()
-  , tfFilter  :: Severity
-  }
+newtype TraceForwarder a = TraceForwarder
+    { getTF :: TraceForwarderMVar }
 
+type TraceForwarderMVar = MVar TraceForwarderInternal
+
+data TraceForwarderInternal = TraceForwarderInternal
+    { tfHandle     :: Maybe Handle
+    , tfRemoteAddr :: RemoteAddr
+    , tfFilter     :: Severity
+    , tfConnector  :: Maybe (Async.Async ())
+    }
 \end{code}
 
 \subsubsection{TraceForwarder is an effectuator}\index{TraceForwarder!instance of IsEffectuator}
@@ -92,18 +103,11 @@ Every |LogObject| before being written to the given handler is converted to
 |ByteString| through its |JSON| represantation.
 \begin{code}
 instance (ToJSON a) => IsEffectuator TraceForwarder a where
-    effectuate tf lo =
-        when (severity meta >= tfFilter tf) $ do
-          tfWrite tf $ encodeUtf8 (hostname meta)
-          tfWrite tf bs
-      where
-        meta = loMeta lo
-        (_, bs) = jsonToBS lo
-
-        jsonToBS :: ToJSON b => b -> (Int, BS.ByteString)
-        jsonToBS a =
-          let bs' = BL.toStrict $ encode a
-          in (BS.length bs', bs')
+    effectuate tf lo = do
+        let currentMVar = getTF tf
+        currentTF <- readMVar currentMVar
+        when (severity (loMeta lo) >= tfFilter currentTF) $
+          traceForwarderWriter currentMVar lo
 
     handleOverflow _ = return ()
 
@@ -121,19 +125,67 @@ instance (FromJSON a, ToJSON a) => IsBackend TraceForwarder a where
 
     realize cfg = getForwardTo cfg >>= \case
       Nothing -> fail "Trace forwarder not configured:  option 'forwardTo'"
-      Just addr -> handleError TraceForwarderConnectionError $
-        withIOManager $ \iomgr -> do
-          h <- connectForwarder iomgr addr
-          pure TraceForwarder
-            { tfClose = hClose h
-            , tfWrite = \bs -> BSC.hPutStrLn h $! bs
-            , tfFilter = Debug  -- default
-            }
+      Just addr -> do
+        tfMVar <- newMVar $ TraceForwarderInternal
+                              { tfHandle     = Nothing
+                              , tfRemoteAddr = addr
+                              , tfFilter     = Debug
+                              , tfConnector  = Nothing
+                              }
+        return $ TraceForwarder tfMVar
 
-    unrealize = tfClose
+    unrealize tf = do
+      currentTF <- readMVar (getTF tf)
+      --If connector thread is active - cancel it.
+      case tfConnector currentTF of
+        Nothing  -> return ()
+        Just thr -> Async.uninterruptibleCancel thr
+      -- If there's a handle - close it.
+      case tfHandle currentTF of
+        Nothing -> return ()
+        Just h  -> hClose h
 
-handleError :: (String -> BackendFailure TraceForwarder) -> IO a -> IO a
-handleError ctor = flip catch $ \(e :: IOException) -> throwIO . ctor . show $ e
+establishConnection :: TraceForwarderMVar -> IO ()
+establishConnection tfMVar = withIOManager $ \iomgr -> do
+  addr <- tfRemoteAddr <$> readMVar tfMVar
+  try (connectForwarder iomgr addr) >>= \case
+    Right h ->
+      modifyMVar_ tfMVar $ \be -> return $ be { tfHandle = Just h }
+    Left (_e :: IOException) -> do
+      -- Cannot establish it, let's try again..
+      threadDelay 1000000 -- 1 s
+      establishConnection tfMVar
+
+traceForwarderWriter :: ToJSON a => TraceForwarderMVar -> LogObject a -> IO ()
+traceForwarderWriter tfMVar lo =
+  tfHandle <$> readMVar tfMVar >>= \case
+    Nothing ->
+      -- There's no handle, connection wasn't established yet.
+      return ()
+    Just h ->
+      try (BSC.hPutStrLn h $! encodeUtf8 (hostname . loMeta $ lo)) >>= \case
+        Right _ ->
+          -- Hostname was written to the handler successfully,
+          -- try to write serialized LogObject.
+          try (BSC.hPutStrLn h $! bs) >>= \case
+            Right _ ->
+              -- Everything is ok, LogObject was written to the handler.
+              return ()
+            Left (_e :: IOException) -> tryToReEstablishConnection
+        Left (_e :: IOException) -> tryToReEstablishConnection
+ where
+  (_, bs) = jsonToBS lo
+
+  jsonToBS :: ToJSON b => b -> (Int, BS.ByteString)
+  jsonToBS a =
+    let bs' = BL.toStrict $ encode a
+    in (BS.length bs', bs')
+
+  -- Handler is here, but it's broken, it looks like the connection with TraceAcceptor
+  -- was interrupted, try to establish it again.
+  tryToReEstablishConnection = do
+    connectorThr <- Async.async $ establishConnection tfMVar
+    modifyMVar_ tfMVar $ \be -> return $ be { tfHandle = Nothing, tfConnector = Just connectorThr } 
 
 connectForwarder :: IOManager -> RemoteAddr -> IO Handle
 connectForwarder iomgr (RemotePipe pipePath) = do


### PR DESCRIPTION
description
-----------

Now shutting down the `TraceAcceptor` process doesn't kill the `TraceForwarder` process.

An example scenario. Node is launched with `TraceForwarderBK`, RTView service is launched with `TraceAcceptorBK`, so:

1. The node can be started even if RTView service doesn't work yet. In this case, the node will try to establish a connection periodically.
2. The node will continue working even if RTView service goes down. In this case, the node will try to establish a connection periodically, and if RTView service is started again, the forwarding will be continued.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
