### PR TITLE
update to iohk-monitoring.cabal on Windows

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -77,7 +77,6 @@ library
     c-sources:         src/Cardano/BM/Counters/os-support-win.c
     include-dirs:      src/Cardano/BM/Counters/
     cc-options:        -DPSAPI_VERSION=2
-    extra-libraries:   psapi
 
   exposed-modules:     Cardano.BM.Counters.Dummy
 


### PR DESCRIPTION

description
-----------

- [x] library included in cabal file prevented cross-compilation in mingw32


checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
