### PR TITLE
adapt for GHC 8.8.x

### DIFF
--- a/contra-tracer/src/Control/Tracer.lhs
+++ b/contra-tracer/src/Control/Tracer.lhs
@@ -31,8 +31,6 @@ module Control.Tracer
 import           Control.Monad (when, (>=>))
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Functor.Contravariant (Contravariant (..))
-import           Data.Semigroup (Semigroup (..))
-import           Data.Monoid (Monoid (..))
 import           Debug.Trace (traceM)
 
 \end{code}


### PR DESCRIPTION

description
-----------

- [x] adapt to newer GHC; still compiles with 8.6.5

has also been proposed in https://github.com/input-output-hk/iohk-monitoring-framework/pull/539
and earlier for GHC 8.8.1 in https://github.com/input-output-hk/iohk-monitoring-framework/commit/958d0d508dc8d028ee9a1a9ddfc2bf1e6eaee3ca

checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
