### PR TITLE
CAD-660 darwin counters

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 5837c635877c11e1bf6c058c8307733c631dc98b
-  --sha256: 1cw1mxwszal0f38m236bfcwdwq2ap1klkqdilv8r836al71djz41
+  tag: c2f1e6b07885ae709446ecb916973c009f16165c
+  --sha256: 0jpqz9jhr297kxsg65gn0l6qls90ydgrypyaxfq2yv8qjx4vpwr2
   subdir: Win32-network
 
 constraints:

--- a/examples/counters/Main.lhs
+++ b/examples/counters/Main.lhs
@@ -1,0 +1,52 @@
+\begin{code}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
+module Main
+  ( main )
+  where
+
+import           Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import           Control.Monad (forever)
+
+import           Cardano.BM.Configuration.Static (defaultConfigStdout)
+import           Cardano.BM.Counters(readCounters)
+import           Cardano.BM.Data.Counter
+import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Observable
+import           Cardano.BM.Data.SubTrace (SubTrace(ObservableTraceSelf))
+import           Cardano.BM.Data.Severity (Severity(Notice))
+import           Cardano.BM.Setup (setupTrace_, shutdown)
+import           Cardano.BM.Trace (Trace, appendName, logInfo, traceNamedObject)
+
+\end{code}
+
+\subsubsection{Entry procedure}
+\begin{code}
+main :: IO ()
+main = do
+    c <- defaultConfigStdout
+    (tr :: Trace IO String, sb) <- setupTrace_ c "counters"
+
+    let trace = appendName "node-metrics" tr
+        counters = [MemoryStats, ProcessStats, NetStats, IOStats, GhcRtsStats, SysStats]
+    thr <- Async.async $ forever $ do
+        cts <- readCounters (ObservableTraceSelf counters)
+        traceCounters trace cts
+        logInfo trace "traced counters."
+        threadDelay 5000000   -- 5 seconds
+
+    Async.link thr
+    threadDelay 30000000  -- 30 seconds
+    Async.cancel thr
+    shutdown sb
+    return ()
+  where
+      traceCounters :: Trace IO String -> [Counter] -> IO ()
+      traceCounters _tr [] = pure ()
+      traceCounters tr (c@(Counter _ct cn cv) : cs) = do
+        mle <- mkLOMeta Notice Confidential
+        traceNamedObject tr (mle, LogValue (nameCounter c <> "." <> cn) cv)
+        traceCounters tr cs
+
+\end{code}

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -36,6 +36,26 @@ executable example-simple
   else
      build-depends:    unix
 
+executable example-counters
+  main-is:             Main.lhs
+  -- other-modules:
+  default-extensions:  OverloadedStrings
+  other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
+  ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-T"
+  build-depends:       base ^>=4.12.0.0
+  hs-source-dirs:      counters
+  default-language:    Haskell2010
+  build-depends:       base,
+                       aeson,
+                       iohk-monitoring,
+                       async,
+                       bytestring,
+                       mtl
+  if os(windows)
+     build-depends:    Win32
+  else
+     build-depends:    unix
+
 executable example-complex
   hs-source-dirs:      complex
   main-is:             Main.lhs

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -5,7 +5,7 @@ synopsis:            logging, benchmarking and monitoring framework
 license:             Apache-2.0
 license-files:       LICENSE, NOTICE
 author:              Alexander Diemand, Andreas Triantafyllos
-maintainer:
+maintainer:          operations@iohk.io
 copyright:           2018 IOHK
 category:            Benchmarking
 build-type:          Simple
@@ -32,6 +32,7 @@ library
 
                        Cardano.BM.Counters
                        Cardano.BM.Counters.Common
+                       Cardano.BM.Counters.Dummy
 
                        Cardano.BM.Data.Aggregated
                        Cardano.BM.Data.AggregatedKind
@@ -77,8 +78,10 @@ library
     c-sources:         src/Cardano/BM/Counters/os-support-win.c
     include-dirs:      src/Cardano/BM/Counters/
     cc-options:        -DPSAPI_VERSION=2
-
-  exposed-modules:     Cardano.BM.Counters.Dummy
+  if os(darwin)
+    exposed-modules:   Cardano.BM.Counters.Darwin
+    c-sources:         src/Cardano/BM/Counters/os-support-darwin.c
+    include-dirs:      src/Cardano/BM/Counters/
 
   other-modules:
 
@@ -130,7 +133,7 @@ library
   if flag(performance-test-queue)
     cpp-options:       -DPERFORMANCE_TEST_QUEUE
 
-  ghc-options:         -Wall -Werror
+  ghc-options:         -Wall
                        -fno-ignore-asserts
 
 test-suite tests
@@ -183,7 +186,7 @@ test-suite tests
                        vector,
                        void,
                        yaml, libyaml
-  ghc-options:         -Wall -Werror -rtsopts "-with-rtsopts=-T"
+  ghc-options:         -Wall -threaded -rtsopts "-with-rtsopts=-T"
 
   if !flag(disable-observables)
     cpp-options:       -DENABLE_OBSERVABLES

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -133,7 +133,7 @@ library
   if flag(performance-test-queue)
     cpp-options:       -DPERFORMANCE_TEST_QUEUE
 
-  ghc-options:         -Wall
+  ghc-options:         -Wall -Werror
                        -fno-ignore-asserts
 
 test-suite tests

--- a/iohk-monitoring/src/Cardano/BM/Counters.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Counters.lhs
@@ -10,23 +10,18 @@ but also partially support |Windows|.
 \begin{code}
 {-# LANGUAGE CPP #-}
 
-#if defined(linux_HOST_OS)
-#define LINUX
-#endif
-#if defined(mingw32_HOST_OS)
-#define WINDOWS
-#endif
-
 module Cardano.BM.Counters
     (
       Platform.readCounters
     , getMonoClock
     ) where
 
-#ifdef LINUX
+#if defined(linux_HOST_OS)
 import qualified Cardano.BM.Counters.Linux as Platform
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 import qualified Cardano.BM.Counters.Windows as Platform
+#elif defined(darwin_HOST_OS)
+import qualified Cardano.BM.Counters.Darwin as Platform
 #else
 import qualified Cardano.BM.Counters.Dummy as Platform
 #endif

--- a/iohk-monitoring/src/Cardano/BM/Counters/Darwin.hsc
+++ b/iohk-monitoring/src/Cardano/BM/Counters/Darwin.hsc
@@ -10,10 +10,8 @@ module Cardano.BM.Counters.Darwin
 
 #ifdef ENABLE_OBSERVABLES
 import           Data.Foldable (foldrM)
--- import           Data.Text (pack)
 import           Data.Word (Word64, Word32, Word8)
 import           Data.Text (pack)
-import           Foreign.C.String
 import           Foreign.C.Types
 import           Foreign.Marshal.Alloc
 import           Foreign.Ptr
@@ -105,6 +103,7 @@ struct host_basic_info {
 	uint64_t                max_mem;                /* actual size of physical memory */
 }; -}
 
+{- currently unused
 data HostBasicInfo = HostBasicInfo
   { _max_cpus :: !CInt
   , _avail_cpus :: !CInt
@@ -135,8 +134,8 @@ instance Storable HostBasicInfo where
                 <*> (#peek struct host_basic_info, logical_cpu_max) ptr
                 <*> (#peek struct host_basic_info, max_mem) ptr
   poke _ _    = pure ()
-
-foreign import ccall unsafe c_get_host_info :: Ptr HostBasicInfo -> IO CInt
+ -}
+-- foreign import ccall unsafe c_get_host_info :: Ptr HostBasicInfo -> IO CInt
 
 foreign import ccall unsafe c_get_boot_time :: IO CInt
 
@@ -404,7 +403,7 @@ getMemoryInfo pid =
 #ifdef ENABLE_OBSERVABLES
 readSysStats :: ProcessID -> IO [Counter]
 readSysStats _pid = do
-    sysinfo <- getSysInfo
+    -- sysinfo <- getSysInfo
     cpuinfo <- getCpuInfo
     bootsecs <- c_get_boot_time
     return [
@@ -427,16 +426,16 @@ readSysStats _pid = do
            , Counter SysInfo "Platform" (PureI $ fromIntegral $ fromEnum Darwin)
            ]
   where
-    getSysInfo :: IO HostBasicInfo
-    getSysInfo =
-      allocaBytes 128 $ \ptr -> do
-        res <- c_get_host_info ptr
-        if res <= 0
-          then do
-            putStrLn $ "c_get_host_info: failure returned: " ++ (show res)
-            return $ HostBasicInfo 0 0 0 0 0 0 0 0 0 0 0
-          else
-            peek ptr
+    -- getSysInfo :: IO HostBasicInfo
+    -- getSysInfo =
+    --   allocaBytes 128 $ \ptr -> do
+    --     res <- c_get_host_info ptr
+    --     if res <= 0
+    --       then do
+    --         putStrLn $ "c_get_host_info: failure returned: " ++ (show res)
+    --         return $ HostBasicInfo 0 0 0 0 0 0 0 0 0 0 0
+    --       else
+    --         peek ptr
     getCpuInfo :: IO CpuTimes
     getCpuInfo =
       allocaBytes 128 $ \ptr -> do
@@ -473,10 +472,10 @@ readProcIO = do
         -- lsnms = map mkdskname (zip [0..32] (_dsknames dskinfo))
     return $ lsn <> concat lscnt
   where
-    mkdskname :: (Int,String) -> Counter
-    mkdskname (n,nm)=
-      let ifnm = "dsk_" <> pack (show nm)
-      in Counter IOCounter ifnm (PureI (fromIntegral n))
+    -- mkdskname :: (Int,String) -> Counter
+    -- mkdskname (n,nm)=
+    --   let ifnm = "dsk_" <> pack (show nm)
+    --   in Counter IOCounter ifnm (PureI (fromIntegral n))
     mkdskcounters :: (Int,DiskInfo) -> [Counter]
     mkdskcounters (num,dta) =
       let nm = "dsk_" <> pack (show num)

--- a/iohk-monitoring/src/Cardano/BM/Counters/Darwin.hsc
+++ b/iohk-monitoring/src/Cardano/BM/Counters/Darwin.hsc
@@ -1,0 +1,544 @@
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Cardano.BM.Counters.Darwin
+    (
+      readCounters
+    , DiskInfo (..)
+    ) where
+
+#ifdef ENABLE_OBSERVABLES
+import           Data.Foldable (foldrM)
+-- import           Data.Text (pack)
+import           Data.Word (Word64, Word32, Word8)
+import           Data.Text (pack)
+import           Foreign.C.String
+import           Foreign.C.Types
+import           Foreign.Marshal.Alloc
+import           Foreign.Ptr
+import           Foreign.Storable
+import           System.Posix.Process (getProcessID)
+import           System.Posix.Types (ProcessID)
+
+import           Cardano.BM.Counters.Common (getMonoClock, readRTSStats)
+import           Cardano.BM.Data.Observable
+import           Cardano.BM.Data.Aggregated (Measurable(..))
+#endif
+import           Cardano.BM.Data.Counter
+import           Cardano.BM.Data.SubTrace
+
+
+#include "os-support-darwin.h"
+
+
+{- type aliases -}
+type MACH_VM_SIZE_T = Word64
+data TIME_VALUE_T = TIME_VALUE_T Word64 Word64
+
+{- memory information -}
+
+{- mach/task_info.h
+struct time_value {
+	integer_t seconds;
+	integer_t microseconds;
+};
+struct mach_task_basic_info {
+	mach_vm_size_t  virtual_size;       /* virtual memory size (bytes) */
+	mach_vm_size_t  resident_size;      /* resident memory size (bytes) */
+	mach_vm_size_t  resident_size_max;  /* maximum resident memory size (bytes) */
+	time_value_t    user_time;          /* total user run time for
+	                                     *  terminated threads */
+	time_value_t    system_time;        /* total system run time for
+	                                     *  terminated threads */
+	policy_t        policy;             /* default policy for new threads */
+	integer_t       suspend_count;      /* suspend count for task */
+}; -}
+
+data MachTaskBasicInfo = MachTaskBasicInfo
+  { _virtual_size :: !MACH_VM_SIZE_T
+  , _resident_size :: !MACH_VM_SIZE_T
+  , _resident_size_max :: !MACH_VM_SIZE_T
+  , _user_time :: !TIME_VALUE_T
+  , _system_time :: !TIME_VALUE_T
+  , _policy :: !Word64
+  , _suspend_count :: !Word64
+  }
+
+instance Storable TIME_VALUE_T where
+  alignment _ = #const offsetof(struct {char x__; struct time_value (y__); }, y__)
+  sizeOf _    = #size struct time_value
+  peek ptr    = TIME_VALUE_T
+                <$> (#peek struct time_value, seconds) ptr
+                <*> (#peek struct time_value, microseconds) ptr
+  poke _ _    = pure ()
+
+instance Storable MachTaskBasicInfo where
+  alignment _ = #const offsetof(struct {char x__; struct mach_task_basic_info (y__); }, y__)
+  sizeOf _    = #size struct mach_task_basic_info
+  peek ptr    = MachTaskBasicInfo
+                <$> (#peek struct mach_task_basic_info, virtual_size) ptr
+                <*> (#peek struct mach_task_basic_info, resident_size) ptr
+                <*> (#peek struct mach_task_basic_info, resident_size_max) ptr
+                <*> (#peek struct mach_task_basic_info, user_time) ptr
+                <*> (#peek struct mach_task_basic_info, system_time) ptr
+                <*> (#peek struct mach_task_basic_info, policy) ptr
+                <*> (#peek struct mach_task_basic_info, suspend_count) ptr
+  poke _ _    = pure ()
+
+foreign import ccall unsafe c_get_process_memory_info :: Ptr MachTaskBasicInfo -> CInt -> IO CInt
+
+{- host information -}
+
+{- mach/host_info.h
+struct host_basic_info {
+	integer_t               max_cpus;               /* max number of CPUs possible */
+	integer_t               avail_cpus;             /* number of CPUs now available */
+	natural_t               memory_size;            /* size of memory in bytes, capped at 2 GB */
+	cpu_type_t              cpu_type;               /* cpu type */
+	cpu_subtype_t           cpu_subtype;            /* cpu subtype */
+	cpu_threadtype_t        cpu_threadtype;         /* cpu threadtype */
+	integer_t               physical_cpu;           /* number of physical CPUs now available */
+	integer_t               physical_cpu_max;       /* max number of physical CPUs possible */
+	integer_t               logical_cpu;            /* number of logical cpu now available */
+	integer_t               logical_cpu_max;        /* max number of physical CPUs possible */
+	uint64_t                max_mem;                /* actual size of physical memory */
+}; -}
+
+data HostBasicInfo = HostBasicInfo
+  { _max_cpus :: !CInt
+  , _avail_cpus :: !CInt
+  , _memory_size :: !CInt
+  , _cpu_type :: !CInt
+  , _cpu_subtype :: !CInt
+  , _cpu_threadtype :: !CInt
+  , _physical_cpu :: !CInt
+  , _physical_cpu_max :: !CInt
+  , _logical_cpu :: !CInt
+  , _logical_cpu_max :: !CInt
+  , _max_mem :: !Word64
+  }
+
+instance Storable HostBasicInfo where
+  alignment _ = #const offsetof(struct {char x__; struct host_basic_info (y__); }, y__)
+  sizeOf _    = #size struct host_basic_info
+  peek ptr    = HostBasicInfo
+                <$> (#peek struct host_basic_info, max_cpus) ptr
+                <*> (#peek struct host_basic_info, avail_cpus) ptr
+                <*> (#peek struct host_basic_info, memory_size) ptr
+                <*> (#peek struct host_basic_info, cpu_type) ptr
+                <*> (#peek struct host_basic_info, cpu_subtype) ptr
+                <*> (#peek struct host_basic_info, cpu_threadtype) ptr
+                <*> (#peek struct host_basic_info, physical_cpu) ptr
+                <*> (#peek struct host_basic_info, physical_cpu_max) ptr
+                <*> (#peek struct host_basic_info, logical_cpu) ptr
+                <*> (#peek struct host_basic_info, logical_cpu_max) ptr
+                <*> (#peek struct host_basic_info, max_mem) ptr
+  poke _ _    = pure ()
+
+foreign import ccall unsafe c_get_host_info :: Ptr HostBasicInfo -> IO CInt
+
+foreign import ccall unsafe c_get_boot_time :: IO CInt
+
+data CpuTimes = CpuTimes {
+    _usertime :: Word64
+  , _systime :: Word64
+  , _idletime :: Word64
+  , _nicetime :: Word64
+  }
+
+instance Storable CpuTimes where
+  alignment _ = #const offsetof(struct {char x__; CPU_TIMES (y__); }, y__)
+  sizeOf _    = #size CPU_TIMES
+  peek ptr    = CpuTimes
+                <$> (#peek CPU_TIMES, usertime) ptr
+                <*> (#peek CPU_TIMES, systime) ptr
+                <*> (#peek CPU_TIMES, idletime) ptr
+                <*> (#peek CPU_TIMES, nicetime) ptr
+  poke _ _    = pure ()
+
+foreign import ccall unsafe c_get_sys_cpu_times :: Ptr CpuTimes -> IO CInt
+
+data DiskInfo = DiskInfo {
+    _reads       :: !Word64
+  , _writes      :: !Word64
+  , _read_bytes  :: !Word64
+  , _write_bytes :: !Word64
+  , _read_time   :: !Word64
+  , _write_time  :: !Word64
+  }
+instance Storable DiskInfo where
+  alignment _ = #const offsetof(struct {char x__; DISK_INFO (y__); }, y__)
+  sizeOf _    = #size DISK_INFO
+  peek ptr    = DiskInfo
+                <$> (#peek DISK_INFO, reads) ptr
+                <*> (#peek DISK_INFO, writes) ptr
+                <*> (#peek DISK_INFO, read_bytes) ptr
+                <*> (#peek DISK_INFO, write_bytes) ptr
+                <*> (#peek DISK_INFO, read_time) ptr
+                <*> (#peek DISK_INFO, write_time) ptr
+  poke _ _    = pure ()
+
+data DiskCounters = DiskCounters {
+    _ndsks    :: !Word32
+  -- , _dsknames :: ![String]
+  , _dsks     :: ![DiskInfo]
+  }
+instance Storable DiskCounters where
+  alignment _ = #const offsetof(struct {char x__; DISK_COUNTERS (y__); }, y__)
+  sizeOf _    = #size DISK_COUNTERS
+  peek ptr    = do
+      n <- (#peek DISK_COUNTERS, ndsks) ptr
+      -- names <- peekStrings (fromIntegral n) ((#ptr DISK_COUNTERS, dsknames) ptr)
+      dskdata <- peekDiskInfo (fromIntegral n) ((#ptr DISK_COUNTERS, dsks) ptr)
+      return $ DiskCounters n dskdata
+  poke _ _    = pure ()
+
+foreign import ccall unsafe c_get_sys_disk_io_counters :: Ptr DiskCounters -> IO CInt
+
+peekDiskInfo :: Int -> Ptr DiskInfo -> IO [DiskInfo]
+peekDiskInfo len ptr = peekDiskInfo' len []
+  where
+    peekDiskInfo' 0 acc = return acc
+    peekDiskInfo' n acc = do
+            let idx = len - n
+            di <- peekElemOff ptr idx
+            peekDiskInfo' (n - 1) (di : acc)
+
+
+{- from net/if_var.h
+/*
+ * Structure describing information about an interface
+ * which may be of interest to management entities.
+ */
+struct if_data {
+	/* generic interface information */
+	u_char          ifi_type;       /* ethernet, tokenring, etc */
+	u_char          ifi_typelen;    /* Length of frame type id */
+	u_char          ifi_physical;   /* e.g., AUI, Thinnet, 10base-T, etc */
+	u_char          ifi_addrlen;    /* media address length */
+	u_char          ifi_hdrlen;     /* media header length */
+	u_char          ifi_recvquota;  /* polling quota for receive intrs */
+	u_char          ifi_xmitquota;  /* polling quota for xmit intrs */
+	u_char          ifi_unused1;    /* for future use */
+	u_int32_t       ifi_mtu;        /* maximum transmission unit */
+	u_int32_t       ifi_metric;     /* routing metric (external only) */
+	u_int32_t       ifi_baudrate;   /* linespeed */
+	/* volatile statistics */
+	u_int32_t       ifi_ipackets;   /* packets received on interface */
+	u_int32_t       ifi_ierrors;    /* input errors on interface */
+	u_int32_t       ifi_opackets;   /* packets sent on interface */
+	u_int32_t       ifi_oerrors;    /* output errors on interface */
+	u_int32_t       ifi_collisions; /* collisions on csma interfaces */
+	u_int32_t       ifi_ibytes;     /* total number of octets received */
+	u_int32_t       ifi_obytes;     /* total number of octets sent */
+	u_int32_t       ifi_imcasts;    /* packets received via multicast */
+	u_int32_t       ifi_omcasts;    /* packets sent via multicast */
+	u_int32_t       ifi_iqdrops;    /* dropped on input, this interface */
+	u_int32_t       ifi_noproto;    /* destined for unsupported protocol */
+	u_int32_t       ifi_recvtiming; /* usec spent receiving when timing */
+	u_int32_t       ifi_xmittiming; /* usec spent xmitting when timing */
+	struct IF_DATA_TIMEVAL ifi_lastchange;  /* time of last administrative change */
+	u_int32_t       ifi_unused2;    /* used to be the default_proto */
+	u_int32_t       ifi_hwassist;   /* HW offload capabilities */
+	u_int32_t       ifi_reserved1;  /* for future use */
+	u_int32_t       ifi_reserved2;  /* for future use */
+};
+ -}
+data IfData64 = IfData64 {
+    _ifi_type :: !Word8
+  -- , _ifi_typelen :: !Word8
+  -- , _ifi_physical :: !Word8
+  -- , _ifi_addrlen :: !Word8
+  -- , _ifi_hdrlen :: !Word8
+  -- , _ifi_recvquota :: !Word8
+  -- , _ifi_xmitquota :: !Word8
+  -- , _ifi_unused1 :: !Word8
+  , _ifi_mtu :: !Word32
+  -- , _ifi_metric :: !Word32
+  , _ifi_baudrate :: !Word32
+  , _ifi_ipackets :: !Word32
+  , _ifi_ierrors :: !Word32
+  , _ifi_opackets :: !Word32
+  , _ifi_oerrors :: !Word32
+  , _ifi_collisions :: !Word32
+  , _ifi_ibytes :: !Word32
+  , _ifi_obytes :: !Word32
+  , _ifi_imcasts :: !Word32
+  , _ifi_omcasts :: !Word32
+  -- , _ifi_iqdrops :: !Word32
+  -- , _ifi_noproto :: !Word32
+  -- , _ifi_recvtiming :: !Word32
+  -- , _ifi_xmittiming :: !Word32
+  -- , _ifi_lastchange :: !Word32
+  -- , _ifi_unused2 :: !Word32
+  -- , _ifi_hwassist :: !Word32
+  -- , _ifi_reserved1 :: !Word32
+  -- , _ifi_reserved2 :: !Word32
+  }
+instance Monoid IfData64 where
+  mempty = IfData64 0 0 0 0 0 0 0 0 0 0 0 0
+instance Semigroup IfData64 where
+  (<>) (IfData64 a1 b1 c1 d1 e1 f1 g1 h1 i1 j1 k1 l1)
+       (IfData64 a2 b2 c2 d2 e2 f2 g2 h2 i2 j2 k2 l2)  =
+       (IfData64 (a1+a2) (b1+b2) (c1+c2) (d1+d2) (e1+e2) (f1+f2) (g1+g2) (h1+h2) (i1+i2) (j1+j2) (k1+k2) (l1+l2)) 
+data NetIO = NetIO {
+    _nifs    :: !Word32
+  -- , _ifnames :: ![String]
+  , _ifs     :: ![IfData64]
+  }
+
+instance Storable IfData64 where
+  alignment _ = #const offsetof(struct {char x__; struct if_data64 (y__); }, y__)
+  sizeOf _    = #size struct if_data64
+  peek ptr    = IfData64
+                <$> (#peek struct if_data64, ifi_type) ptr
+                <*> (#peek struct if_data64, ifi_mtu) ptr
+                <*> (#peek struct if_data64, ifi_baudrate) ptr
+                <*> (#peek struct if_data64, ifi_ipackets) ptr
+                <*> (#peek struct if_data64, ifi_ierrors) ptr
+                <*> (#peek struct if_data64, ifi_opackets) ptr
+                <*> (#peek struct if_data64, ifi_oerrors) ptr
+                <*> (#peek struct if_data64, ifi_collisions) ptr
+                <*> (#peek struct if_data64, ifi_ibytes) ptr
+                <*> (#peek struct if_data64, ifi_obytes) ptr
+                <*> (#peek struct if_data64, ifi_imcasts) ptr
+                <*> (#peek struct if_data64, ifi_omcasts) ptr
+  poke _ _    = pure ()
+
+instance Storable NetIO where
+  alignment _ = #const offsetof(struct {char x__; NET_IO (y__); }, y__)
+  sizeOf _    = #size NET_IO
+  peek ptr    = do
+      n <- (#peek NET_IO, nifs) ptr
+      -- names <- peekStrings (fromIntegral n) ((#ptr NET_IO, ifnames) ptr)
+      ifdata <- peekIfData64 (fromIntegral n) ((#ptr NET_IO, ifs) ptr)
+      return $ NetIO n ifdata
+  poke _ _    = pure ()
+
+foreign import ccall unsafe c_get_sys_network_io_counters :: Ptr NetIO -> IO CInt
+
+peekIfData64 :: Int -> Ptr IfData64 -> IO [IfData64]
+peekIfData64 len ptr = peekIfData64' len []
+  where
+    peekIfData64' 0 acc = return acc
+    peekIfData64' n acc = do
+        let idx = len - n
+        ifd <- peekElemOff ptr idx
+        peekIfData64' (n - 1) (ifd : acc)
+
+{- peekStrings :: Int -> Ptr CString -> IO [String]
+peekStrings len ptr = peekStrings' len []
+  where
+    peekStrings' 0 acc = return acc
+    peekStrings' n acc = do
+        let idx = len - n
+        s <- peekCString =<< peekElemOff ptr idx
+        peekStrings' (n - 1) (s : acc) -}
+
+{-  -}
+
+readCounters :: SubTrace -> IO [Counter]
+readCounters NoTrace                   = return []
+readCounters Neutral                   = return []
+readCounters (TeeTrace _)              = return []
+readCounters (FilterTrace _)           = return []
+readCounters UntimedTrace              = return []
+readCounters DropOpening               = return []
+readCounters (SetSeverity _)           = return []
+#ifdef ENABLE_OBSERVABLES
+readCounters (ObservableTraceSelf tts) = do
+    pid <- getProcessID
+    takeMeasurements pid tts
+readCounters (ObservableTrace _pid _tts) = return []
+
+takeMeasurements :: ProcessID -> [ObservableInstance] -> IO [Counter]
+takeMeasurements pid tts =
+    foldrM (\(sel, fun) a ->
+       if any (== sel) tts
+          then do
+              xs <- fun
+              return (a ++ xs)
+          else pure a) [] selectors
+  where
+    selectors = [ (MonotonicClock, getMonoClock)
+                , (SysStats, readSysStats pid)
+                , (MemoryStats, readProcMem pid)
+                , (ProcessStats, readProcStats pid)
+                , (NetStats, readProcNet)
+                , (IOStats, readProcIO)
+                , (GhcRtsStats, readRTSStats)
+                ]
+#else
+readCounters (ObservableTraceSelf _)   = return []
+readCounters (ObservableTrace     _ _) = return []
+#endif
+
+
+#ifdef ENABLE_OBSERVABLES
+usFromTimeValue :: TIME_VALUE_T -> Word64
+usFromTimeValue (TIME_VALUE_T s us) = s * 1000000 + us
+
+readProcMem :: ProcessID -> IO [Counter]
+readProcMem pid = do
+    meminfo <- getMemoryInfo pid
+    return [ Counter MemoryCounter "Pid" (PureI $ fromIntegral pid)
+           , Counter MemoryCounter "virtual_size" (Bytes $ fromIntegral (_virtual_size meminfo))
+           , Counter MemoryCounter "resident_size" (Bytes $ fromIntegral (_resident_size meminfo))
+           , Counter MemoryCounter "resident_size_max" (Bytes $ fromIntegral (_resident_size_max meminfo))
+           ]
+
+getMemoryInfo :: ProcessID -> IO MachTaskBasicInfo
+getMemoryInfo pid =
+  allocaBytes 128 $ \ptr -> do
+    res <- c_get_process_memory_info ptr (fromIntegral pid)
+    if res <= 0
+      then do
+        putStrLn $ "c_get_process_memory_info: failure returned: " ++ (show res)
+        return $ MachTaskBasicInfo 0 0 0 (TIME_VALUE_T 0 0) (TIME_VALUE_T 0 0) 0 0
+      else
+        peek ptr
+#endif
+
+
+#ifdef ENABLE_OBSERVABLES
+readSysStats :: ProcessID -> IO [Counter]
+readSysStats _pid = do
+    sysinfo <- getSysInfo
+    cpuinfo <- getCpuInfo
+    bootsecs <- c_get_boot_time
+    return [
+          --    Counter SysInfo "memory_size" (Bytes $ fromIntegral (_memory_size sysinfo))
+          --  , Counter SysInfo "max_cpus" (PureI $ fromIntegral (_max_cpus sysinfo))
+          --  , Counter SysInfo "avail_cpus" (PureI $ fromIntegral (_avail_cpus sysinfo))
+          --  , Counter SysInfo "cpu_type" (PureI $ fromIntegral (_cpu_type sysinfo))
+          --  , Counter SysInfo "cpu_subtype" (PureI $ fromIntegral (_cpu_subtype sysinfo))
+          --  , Counter SysInfo "cpu_threadtype" (PureI $ fromIntegral (_cpu_threadtype sysinfo))
+          --  , Counter SysInfo "physical_cpu" (PureI $ fromIntegral (_physical_cpu sysinfo))
+          --  , Counter SysInfo "physical_cpu_max" (PureI $ fromIntegral (_physical_cpu_max sysinfo))
+          --  , Counter SysInfo "logical_cpu" (PureI $ fromIntegral (_logical_cpu sysinfo))
+          --  , Counter SysInfo "logical_cpu_max" (PureI $ fromIntegral (_logical_cpu_max sysinfo))
+          --  , Counter SysInfo "max_mem" (Bytes $ fromIntegral (_max_mem sysinfo))
+             Counter SysInfo "boot_time" (Seconds $ fromIntegral bootsecs)
+           , Counter SysInfo "SysUserTime" (Nanoseconds $ fromIntegral (1000 * _usertime cpuinfo))
+           , Counter SysInfo "SystemTime" (Nanoseconds $ fromIntegral (1000 * _systime cpuinfo))
+           , Counter SysInfo "IdleTime" (Nanoseconds $ fromIntegral (1000 * _idletime cpuinfo))
+           , Counter SysInfo "NiceTime" (Nanoseconds $ fromIntegral (1000 * _nicetime cpuinfo))
+           , Counter SysInfo "Platform" (PureI $ fromIntegral $ fromEnum Darwin)
+           ]
+  where
+    getSysInfo :: IO HostBasicInfo
+    getSysInfo =
+      allocaBytes 128 $ \ptr -> do
+        res <- c_get_host_info ptr
+        if res <= 0
+          then do
+            putStrLn $ "c_get_host_info: failure returned: " ++ (show res)
+            return $ HostBasicInfo 0 0 0 0 0 0 0 0 0 0 0
+          else
+            peek ptr
+    getCpuInfo :: IO CpuTimes
+    getCpuInfo =
+      allocaBytes 128 $ \ptr -> do
+        res <- c_get_sys_cpu_times ptr
+        if res <= 0
+          then do
+            putStrLn $ "c_get_sys_cpu_times: failure returned: " ++ (show res)
+            return $ CpuTimes 0 0 0 0
+          else
+            peek ptr
+#endif
+
+
+#ifdef ENABLE_OBSERVABLES
+readProcStats :: ProcessID -> IO [Counter]
+readProcStats pid = do
+    meminfo <- getMemoryInfo pid
+    return [ Counter StatInfo "Pid" (PureI $ fromIntegral pid)
+           , Counter StatInfo "user_time" (Nanoseconds $ 1000 * usFromTimeValue (_user_time meminfo))
+           , Counter StatInfo "system_time" (Nanoseconds $ 1000 * usFromTimeValue (_system_time meminfo))
+           , Counter StatInfo "policy" (PureI $ fromIntegral (_policy meminfo))
+           , Counter StatInfo "suspend_count" (PureI $ fromIntegral (_suspend_count meminfo))
+           ]
+#endif
+
+
+#ifdef ENABLE_OBSERVABLES
+readProcIO :: IO [Counter]
+readProcIO = do
+    dskinfo <- getDiskInfo
+    let ndsks = _ndsks dskinfo
+        lsn = [ Counter IOCounter "ndisks" (PureI $ fromIntegral ndsks)]
+        lscnt = map mkdskcounters (zip [0..32] (_dsks dskinfo))
+        -- lsnms = map mkdskname (zip [0..32] (_dsknames dskinfo))
+    return $ lsn <> concat lscnt
+  where
+    mkdskname :: (Int,String) -> Counter
+    mkdskname (n,nm)=
+      let ifnm = "dsk_" <> pack (show nm)
+      in Counter IOCounter ifnm (PureI (fromIntegral n))
+    mkdskcounters :: (Int,DiskInfo) -> [Counter]
+    mkdskcounters (num,dta) =
+      let nm = "dsk_" <> pack (show num)
+      in [ Counter IOCounter (nm<>"-reads") (PureI $ fromIntegral (_reads dta))
+         , Counter IOCounter (nm<>"-read_bytes") (Bytes $ fromIntegral (_read_bytes dta))
+         , Counter IOCounter (nm<>"-writes") (PureI $ fromIntegral (_writes dta))
+         , Counter IOCounter (nm<>"-write_bytes") (Bytes $ fromIntegral (_write_bytes dta))
+         ]
+    getDiskInfo :: IO DiskCounters
+    getDiskInfo =
+      allocaBytes (#size DISK_COUNTERS) $ \ptr -> do
+        res <- c_get_sys_disk_io_counters ptr
+        if res <= 0
+          then do
+            putStrLn $ "c_get_sys_disk_io_counters: failure returned: " ++ (show res)
+            return $ DiskCounters 0 []
+          else
+            peek ptr
+#endif
+
+
+#ifdef ENABLE_OBSERVABLES
+readProcNet :: IO [Counter]
+readProcNet = do
+    netinfo <- getNetInfo
+    let n = _nifs netinfo
+        lsn = [ Counter NetCounter "interfaces" (PureI $ fromIntegral n)]
+        -- lscnt = map mkifcounters (zip [1..31] (_ifs netinfo))
+        -- lsnms = map mkifname (zip [1..31] (_ifnames netinfo))
+        lssum = mkifname (0, "summary")
+              : mkifcounters (0, ifsum (_ifs netinfo))
+    return $ lsn <> lssum
+  where
+    getNetInfo :: IO NetIO
+    getNetInfo = do
+      allocaBytes (#size NET_IO) $ \ptr -> do
+        res <- c_get_sys_network_io_counters ptr
+        if res <= 0
+          then do
+            putStrLn $ "c_get_sys_network_io_counters: failure returned: " ++ (show res)
+            return $ NetIO 0 []
+          else
+            peek ptr
+    ifsum :: [IfData64] -> IfData64
+    ifsum = foldr (\ifd acc -> ifd <> acc) mempty
+    mkifname :: (Int,String) -> Counter
+    mkifname (n,nm)=
+      let ifnm = "ifn_" <> pack (show nm)
+      in Counter NetCounter ifnm (PureI (fromIntegral n))
+    mkifcounters :: (Int,IfData64) -> [Counter]
+    mkifcounters (num,dta) =
+      let nm = "ifd_" <> pack (show num)
+      in [ Counter NetCounter (nm<>"-mtu") (Bytes $ fromIntegral (_ifi_mtu dta))
+         , Counter NetCounter (nm<>"-ipackets") (PureI $ fromIntegral (_ifi_ipackets dta))
+         , Counter NetCounter (nm<>"-ierrors") (PureI $ fromIntegral (_ifi_ierrors dta))
+         , Counter NetCounter (nm<>"-opackets") (PureI $ fromIntegral (_ifi_opackets dta))
+         , Counter NetCounter (nm<>"-oerrors") (PureI $ fromIntegral (_ifi_oerrors dta))
+         , Counter NetCounter (nm<>"-collisions") (PureI $ fromIntegral (_ifi_collisions dta))
+         , Counter NetCounter (nm<>"-ibytes") (Bytes $ fromIntegral (_ifi_ibytes dta))
+         , Counter NetCounter (nm<>"-obytes") (Bytes $ fromIntegral (_ifi_obytes dta))
+         , Counter NetCounter (nm<>"-imcast") (PureI $ fromIntegral (_ifi_imcasts dta))
+         , Counter NetCounter (nm<>"-omcast") (PureI $ fromIntegral (_ifi_omcasts dta))
+         ]
+
+#endif

--- a/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.c
+++ b/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.c
@@ -1,0 +1,272 @@
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/task.h>
+#include <mach/task_info.h>
+#include <mach/mach_init.h>
+#include <mach/mach_host.h>
+#include <net/route.h>
+#include <net/if_dl.h>
+
+/*
+// includes for c_get_sys_disk_io_counters
+// will require GHC options in cabal file:
+//   if os(darwin)
+//     ghc-options:       -framework CoreFoundation -framework IOKit
+//
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/storage/IOBlockStorageDriver.h>
+#include <IOKit/storage/IOMedia.h>
+#include <IOKit/IOBSD.h>
+#include <IOKit/ps/IOPowerSources.h>
+#include <IOKit/ps/IOPSKeys.h>
+*/
+#include "os-support-darwin.h"
+
+
+/* c_get_process_memory_info */
+
+int c_get_process_memory_info(struct mach_task_basic_info *counters, int pid)
+{
+    task_t task = MACH_PORT_NULL;
+    if (task_for_pid(current_task(), pid, &task) != KERN_SUCCESS) {
+        return -2;
+    }
+    struct mach_task_basic_info t_info;
+    mach_msg_type_number_t t_info_count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(task, MACH_TASK_BASIC_INFO, (task_info_t)counters, &t_info_count) != KERN_SUCCESS) {
+        return -1;
+    }
+    return 1;
+}
+
+
+/* c_get_host_info */
+
+int c_get_host_info(struct host_basic_info *counters)
+{
+    mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
+    mach_port_t host_port = mach_host_self();
+    if (host_statistics(host_port, HOST_BASIC_INFO,
+                            (host_info_t)counters, &count) != KERN_SUCCESS) {
+        return -2;
+    }
+    mach_port_deallocate(mach_task_self(), host_port);
+    return 1;
+}
+
+/* c_get_boot_time */
+
+long c_get_boot_time()
+{
+    // copied from psutil
+    // fetch sysctl "kern.boottime"
+    static int request[2] = { CTL_KERN, KERN_BOOTTIME };
+    struct timeval result;
+    size_t result_len = sizeof result;
+    time_t boot_time = 0;
+
+    if (sysctl(request, 2, &result, &result_len, NULL, 0) == -1) {
+        return -1;
+    }
+    return result.tv_sec;
+}
+
+/* c_get_sys_cpu_times */
+int c_get_sys_cpu_times(CPU_TIMES *counters)
+{
+    mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
+    host_cpu_load_info_data_t r_load;
+
+    mach_port_t host_port = mach_host_self();
+    if (host_statistics(host_port, HOST_CPU_LOAD_INFO,
+                            (host_info_t)&r_load, &count) != KERN_SUCCESS) {
+        return -2;
+    }
+    mach_port_deallocate(mach_task_self(), host_port);
+    counters->usertime = r_load.cpu_ticks[CPU_STATE_USER] * 100000 / CLK_TCK;
+    counters->systime = r_load.cpu_ticks[CPU_STATE_SYSTEM] * 100000 / CLK_TCK;
+    counters->idletime = r_load.cpu_ticks[CPU_STATE_IDLE] * 100000 / CLK_TCK;
+    counters->nicetime = r_load.cpu_ticks[CPU_STATE_NICE] * 100000 / CLK_TCK;
+    return 1;
+}
+
+/* c_get_proc_cpu_times */
+
+
+
+/* c_get_sys_disk_io_counters */
+/* adapted from psutil */
+int c_get_sys_disk_io_counters(DISK_COUNTERS *counters) {
+    counters->ndsks = 0;
+    // uncomment the following to extract disk I/O metrics
+    // requires to include the right headers (see top of this file)
+    // and link to frameworks on Darwin (also described there)
+/*
+    int noutput = 0;
+    CFDictionaryRef parent_dict;
+    CFDictionaryRef props_dict;
+    CFDictionaryRef stats_dict;
+    io_registry_entry_t parent;
+    io_registry_entry_t disk;
+    io_iterator_t disk_list;
+
+    // Get list of disks
+    if (IOServiceGetMatchingServices(
+            kIOMasterPortDefault,
+            IOServiceMatching(kIOMediaClass),
+            &disk_list) != kIOReturnSuccess) {
+        return -4;
+    }
+
+    // Iterate over disks
+    while ((disk = IOIteratorNext(disk_list)) != 0) {
+        parent_dict = NULL;
+        props_dict = NULL;
+        stats_dict = NULL;
+
+        if (IORegistryEntryGetParentEntry(disk, kIOServicePlane, &parent) != kIOReturnSuccess) {
+            return -3;
+        }
+
+        if (IOObjectConformsTo(parent, "IOBlockStorageDriver")) {
+
+            if (IORegistryEntryCreateCFProperties(disk,
+                    (CFMutableDictionaryRef *) &parent_dict,
+                    kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
+                IOObjectRelease(disk);
+                IOObjectRelease(parent);
+                return -2;
+            }
+
+            if (IORegistryEntryCreateCFProperties(parent,
+                    (CFMutableDictionaryRef *) &props_dict,
+                    kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
+                CFRelease(props_dict);
+                IOObjectRelease(disk);
+                IOObjectRelease(parent);
+                return -1;
+            }
+
+            const int kMaxDiskNameSize = 64;
+            char disk_name[kMaxDiskNameSize+1]; memset(disk_name, 0, kMaxDiskNameSize+1);
+            CFStringRef disk_name_ref = (CFStringRef)
+                CFDictionaryGetValue(parent_dict, CFSTR(kIOBSDNameKey));
+            CFStringGetCString(disk_name_ref, disk_name,
+                               kMaxDiskNameSize,
+                               CFStringGetSystemEncoding());
+            counters->dsknames[noutput] = strdup(disk_name);
+
+            stats_dict = (CFDictionaryRef)
+                CFDictionaryGetValue(props_dict, CFSTR(kIOBlockStorageDriverStatisticsKey));
+            if (stats_dict == NULL) {
+                continue;
+            }
+            CFNumberRef number;
+            int64_t t_num64 = 0;
+            // Get disk reads/writes
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsReadsKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].reads = t_num64;
+            }
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsWritesKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].writes = t_num64;
+            }
+            // Get disk bytes read/written
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsBytesReadKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].read_bytes = t_num64;
+            }
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsBytesWrittenKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].write_bytes = t_num64;
+            }
+            // Get disk time spent reading/writing (nanoseconds)
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsTotalReadTimeKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].read_time = t_num64;
+            }
+            if ((number = (CFNumberRef)CFDictionaryGetValue(stats_dict,
+                    CFSTR(kIOBlockStorageDriverStatisticsTotalWriteTimeKey)))) {
+                CFNumberGetValue(number, kCFNumberSInt64Type, &t_num64);
+                counters->dsks[noutput].write_time = t_num64;
+            }
+
+            CFRelease(parent_dict);
+            IOObjectRelease(parent);
+            CFRelease(props_dict);
+            IOObjectRelease(disk);
+
+            noutput++;
+            if (noutput >= MAX_DISK_COUNTERS) { break; }
+        }
+    } // while
+    IOObjectRelease (disk_list);
+    counters->ndsks = noutput;
+*/
+    return 1;
+}
+
+/* c_get_sys_network_io_counters */
+/* adapted from psutil */
+int c_get_sys_network_io_counters(NET_IO *counters) {
+    counters->nifs = 0;
+    int noutput = 0;
+    char *msghdrbuf = NULL, *end_of_list, *next;
+    struct if_msghdr *ifm;
+    int mib[6];
+    mib[0] = CTL_NET;          // networking subsystem
+    mib[1] = PF_ROUTE;         // type of information
+    mib[2] = 0;                // protocol (IPPROTO_xxx)
+    mib[3] = 0;                // address family
+    mib[4] = NET_RT_IFLIST2;   // operation
+    mib[5] = 0;
+    size_t buflen;
+    if (sysctl(mib, 6, NULL, &buflen, NULL, 0) < 0) {
+        return -4;
+    }
+
+    msghdrbuf = malloc(buflen);
+    if (msghdrbuf == NULL) {
+        return -3;
+    }
+    if (sysctl(mib, 6, msghdrbuf, &buflen, NULL, 0) < 0) {
+        return -2;
+    }
+
+    char nmbuf[12+1];
+
+    end_of_list = msghdrbuf + buflen;
+    for (next = msghdrbuf; next < end_of_list; ) {
+        ifm = (struct if_msghdr *)next;
+        next += ifm->ifm_msglen;
+        if (ifm->ifm_type == RTM_IFINFO2 && (ifm->ifm_flags & IFF_UP)) {
+            struct if_msghdr2 *if2m = (struct if_msghdr2 *)ifm;
+            // access name of interface and make a copy of the string
+            // struct sockaddr_dl *sdl = (struct sockaddr_dl *)(if2m + 1);
+            // memset(nmbuf, 0, 12+1);
+            // strncpy(nmbuf, sdl->sdl_data, MIN(12,sdl->sdl_nlen));
+            // counters->ifnames[noutput] = strdup(nmbuf);
+
+            // copy struct if_data64
+            memcpy(&counters->ifs[noutput], &if2m->ifm_data, sizeof(struct if_data64));
+            noutput++;
+        }
+        if (noutput >= MAX_NET_IO) { break; }
+    }
+    counters->nifs = noutput;
+    free(msghdrbuf);
+    return 1;
+}

--- a/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.c
+++ b/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.c
@@ -48,7 +48,7 @@ int c_get_process_memory_info(struct mach_task_basic_info *counters, int pid)
 
 
 /* c_get_host_info */
-
+/* currently this is not used
 int c_get_host_info(struct host_basic_info *counters)
 {
     mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
@@ -59,7 +59,7 @@ int c_get_host_info(struct host_basic_info *counters)
     }
     mach_port_deallocate(mach_task_self(), host_port);
     return 1;
-}
+} */
 
 /* c_get_boot_time */
 

--- a/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.h
+++ b/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.h
@@ -30,7 +30,7 @@ typedef struct _DISK_COUNTERS {
 } DISK_COUNTERS;
 
 int c_get_process_memory_info (struct mach_task_basic_info *counters, int pid);
-int c_get_host_info (struct host_basic_info *counters);
+//int c_get_host_info (struct host_basic_info *counters);
 long c_get_boot_time();
 int c_get_sys_cpu_times(CPU_TIMES *counters);
 int c_get_sys_network_io_counters(NET_IO *counters);

--- a/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.h
+++ b/iohk-monitoring/src/Cardano/BM/Counters/os-support-darwin.h
@@ -1,0 +1,37 @@
+#include <mach/task_info.h>
+#include <mach/host_info.h>
+#include <net/if.h>
+#include <net/if_var.h>
+
+typedef struct _CPU_TIMES {
+  int64_t usertime;
+  int64_t systime;
+  int64_t idletime;
+  int64_t nicetime;
+} CPU_TIMES;
+
+#define MAX_NET_IO 32
+typedef struct _NET_IO {
+    u_int32_t nifs;
+    char* ifnames[MAX_NET_IO];
+    struct if_data64 ifs[MAX_NET_IO];
+} NET_IO;
+
+typedef struct _DISK_INFO {
+    int64_t reads, writes;
+    int64_t read_bytes, write_bytes;
+    int64_t read_time, write_time;  // nanoseconds
+} DISK_INFO;
+#define MAX_DISK_COUNTERS 32
+typedef struct _DISK_COUNTERS {
+    u_int32_t ndsks;
+    char* dsknames[MAX_DISK_COUNTERS];
+    DISK_INFO dsks[MAX_DISK_COUNTERS];
+} DISK_COUNTERS;
+
+int c_get_process_memory_info (struct mach_task_basic_info *counters, int pid);
+int c_get_host_info (struct host_basic_info *counters);
+long c_get_boot_time();
+int c_get_sys_cpu_times(CPU_TIMES *counters);
+int c_get_sys_network_io_counters(NET_IO *counters);
+int c_get_sys_disk_io_counters(DISK_COUNTERS *counters);

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.26
+resolver: lts-14.27
 compiler: ghc-8.6.5
 
 packages:
@@ -28,7 +28,7 @@ extra-deps:
   - libsystemd-journal-1.4.4
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 5837c635877c11e1bf6c058c8307733c631dc98b
+    commit: c2f1e6b07885ae709446ecb916973c009f16165c
     subdirs:
         - Win32-network
 


### PR DESCRIPTION
description
-----------

- [x] counters on MacOSX/Darwin

output on a Mac:

```
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.bytesAllocated = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.liveBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.maxLiveBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.maxLargeBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.maxCompactBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.maxSlopBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.maxUsedMemBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcLiveBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcCopiedBytes = 0 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcCpuNs = 0.0 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcElapsedNs = 0.0 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.cpuNs = 2.2e-4 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.elapsedNs = 3.6572e-4 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcNum = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] RTS.gcMajorNum = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] IO.ndisks = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.interfaces = 10
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifn_"summary" = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-mtu = 30264 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-ipackets = 4766773
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-ierrors = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-opackets = 1807907
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-oerrors = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-collisions = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-ibytes = 959728640 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-obytes = 368784384 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-imcast = 641191
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Net.ifd_0-omcast = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Stat.Pid = 32808
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Stat.user_time = 1.5352714e10 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Stat.system_time = 4.9055857e9 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Stat.policy = 1
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Stat.suspend_count = 0
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Mem.Pid = 32808
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Mem.virtual_size = 1103910191104 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Mem.resident_size = 5664768 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Mem.resident_size_max = 5664768 B
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.boot_time = 1588347521 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.SysUserTime = 4.332867 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.SystemTime = 17.283087 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.IdleTime = 10.040732 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.NiceTime = 0.0 s
[counters.node-metrics:Notice:11] [2020-05-07 11:17:20.93 UTC] Sys.Platform = 2
```

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
