### PR TITLE
CAD-880: Forwarder and acceptor performance

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -244,6 +244,8 @@ output could also be forwarded using a pipe:
     CM.setForwardTo c (Just $ RemoteSocket "127.0.0.1" "42999")
     CM.setTextOption c "forwarderMinSeverity" "Warning"  -- sets min severity filter in forwarder
 
+    CM.setForwardDelay c (Just 1000)
+
     CM.setMonitors c $ HM.fromList
         [ ( "complex.monitoring"
           , ( Just (Compare "monitMe" (GE, OpMeasurable 10))

--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -18,6 +18,8 @@ module Cardano.BM.Configuration
     , CM.getBackends
     , CM.getForwardTo
     , CM.setForwardTo
+    , CM.getForwardDelay
+    , CM.setForwardDelay
     , CM.getOption
     , CM.getMapOption
     , CM.getTextOption

--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -58,6 +58,7 @@ data Representation = Representation
     , hasPrometheus   :: Maybe HostPort
     , hasGUI          :: Maybe Port
     , traceForwardTo  :: Maybe RemoteAddr
+    , forwardDelay    :: Maybe Word
     , traceAcceptAt   :: Maybe [RemoteAddrNamed]
     , options         :: HM.HashMap Text Value
     }

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -106,6 +106,7 @@ unitConfigurationStaticRepresentation =
             , hasEKG = Just 18321
             , hasPrometheus = Just ("localhost", 12799)
             , traceForwardTo = Just (RemotePipe "to")
+            , forwardDelay = Just 1000
             , traceAcceptAt = Just [RemoteAddrNamed "a" (RemotePipe "at")]
             , options =
                 HM.fromList [ ("test1", Object (HM.singleton "value" "object1"))
@@ -151,6 +152,7 @@ unitConfigurationStaticRepresentation =
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
             , "hasEKG: 18321"
+            , "forwardDelay: 1000"
             , "minSeverity: Info"
             , "" -- to force a line feed at the end of the file
             ]
@@ -242,6 +244,7 @@ unitConfigurationParsedRepresentation = do
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
             , "hasEKG: 12789"
+            , "forwardDelay: 1000"
             , "minSeverity: Info"
             , "" -- to force a line feed at the end of the file
             ]
@@ -384,6 +387,7 @@ unitConfigurationParsed = do
         , cgBindAddrPrometheus = Nothing
         , cgPortGUI           = 0
         , cgForwardTo         = Just (RemotePipe "to")
+        , cgForwardDelay      = Just 1000
         , cgAcceptAt          = Just [RemoteAddrNamed "a" (RemotePipe "at")]
         }
 

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -101,6 +101,8 @@ traceForwardTo:
   tag: RemotePipe
   contents: to
 
+forwardDelay: 1000
+
 traceAcceptAt:
   - remoteAddr:
       tag: RemotePipe

--- a/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -22,7 +22,7 @@ module Cardano.BM.Backend.TraceForwarder
     ) where
 
 import           Control.Exception
-import           Control.Monad (when)
+import           Control.Monad (forever, when)
 import           Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.Async as Async
 import           Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, readMVar)
@@ -73,7 +73,7 @@ plugin config _trace _sb tfid = do
                    Nothing -> Debug
                    Just sevtext -> fromMaybe Debug (readMaybe $ unpack sevtext)
     be :: Cardano.BM.Backend.TraceForwarder.TraceForwarder a <- realize config
-    dispatcherThr <- spawnDispatcher (getTF be)
+    dispatcherThr <- spawnDispatcher config (getTF be)
     modifyMVar_ (getTF be) $ \initialBE ->
       return $ initialBE
                  { tfFilter     = minsev
@@ -186,51 +186,59 @@ instance Exception TraceForwarderBackendFailure
 
 \subsubsection{Asynchronously reading log items from the queue and sending them to an acceptor.}
 \begin{code}
-spawnDispatcher :: ToJSON a => TraceForwarderMVar a -> IO (Async.Async ())
-spawnDispatcher tfMVar = Async.async $ processQueue
+spawnDispatcher :: ToJSON a => Configuration -> TraceForwarderMVar a -> IO (Async.Async ())
+spawnDispatcher config tfMVar = do
+  -- To reduce network traffic it's possible to send log items not one by one,
+  -- but collect them in the queue and periodically send this list as one ByteString.
+  forwardDelay <- getForwardDelay config >>= \case
+    Nothing -> pure defaultDelayInMs
+    Just delayInMs -> pure delayInMs
+  Async.async $ processQueue forwardDelay
  where
-  processQueue :: IO ()
-  processQueue = do
+  -- If the configuration doesn't specify forward delay, use default one.
+  defaultDelayInMs :: Word
+  defaultDelayInMs = 1000
+
+  processQueue :: Word -> IO ()
+  processQueue delayInMs = forever $ do
+    threadDelay $ fromIntegral delayInMs * 1000
     currentTF <- readMVar tfMVar
-    -- Read the next log item from the queue. If the queue is still empty -
-    -- blocking and waiting for the next log item.
-    nextItem <- atomically $ TBQ.readTBQueue (tfQueue currentTF)
+    itemsList <- atomically $ TBQ.flushTBQueue (tfQueue currentTF)
     -- Try to write it to the handle. If there's a problem with connection,
     -- this thread will initiate re\-establishing of the connection and
     -- will wait until it's established.
-    sendItem tfMVar nextItem
-    -- Continue...
-    processQueue
+    sendItems config tfMVar itemsList
 
--- Try to send log item to the handle.
-sendItem :: ToJSON a => TraceForwarderMVar a -> LogObject a -> IO ()
-sendItem tfMVar lo =
+-- Try to send log items to the handle.
+sendItems :: ToJSON a => Configuration -> TraceForwarderMVar a -> [LogObject a] -> IO ()
+sendItems _ _ [] = return ()
+sendItems config tfMVar items@(lo:_) =
   tfHandle <$> readMVar tfMVar >>= \case
     Nothing -> do
       -- There's no handle, initiate the connection.
       establishConnection 1 1 tfMVar
       -- Connection is re\-established, try to send log item.
-      sendItem tfMVar lo
+      sendItems config tfMVar items
     Just h ->
       try (BSC.hPutStrLn h $! encodedHostname) >>= \case
         Right _ ->
           -- Hostname was written to the handler successfully,
-          -- try to write serialized LogObject.
+          -- try to write serialized list of LogObjects.
           try (BSC.hPutStrLn h $! bs) >>= \case
             Right _ ->
-              return () -- Everything is ok, LogObject was written to the handler.
+              return () -- Everything is ok, LogObjects were written to the handler.
             Left (_e :: IOException) -> do
               reConnectIfQueueIsAlmostFull
               threadDelay 10000
-              sendItem tfMVar lo
+              sendItems config tfMVar items
         Left (_e :: IOException) -> do
           reConnectIfQueueIsAlmostFull
           threadDelay 10000
-          sendItem tfMVar lo
+          sendItems config tfMVar items
  where
   encodedHostname = encodeUtf8 (hostname . loMeta $ lo)
 
-  (_, bs) = jsonToBS lo
+  (_, bs) = jsonToBS items
 
   jsonToBS :: ToJSON b => b -> (Int, BS.ByteString)
   jsonToBS a =

--- a/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -264,7 +264,7 @@ sendItems config tfMVar items@(lo:_) =
     almostFullSize = 0.8 * fromIntegral queueMaxSize
 
 queueMaxSize :: Natural
-queueMaxSize = 500
+queueMaxSize = 2500
 
 establishConnection :: Int -> Int -> TraceForwarderMVar a -> IO ()
 establishConnection delayInSec delayInSec' tfMVar = withIOManager $ \iomgr -> do


### PR DESCRIPTION
description
-----------

Previously `TraceForwarder` was sending `LogObject`s one by one. Moreover, each log item corresponded to 2 `ByteString`s: encoded hostname and encoded `LogObject`. Now `TraceForwarder` collects `LogObject`s in the queue and sends them periodically as one big `ByteString`. The period is defined in configuration (as a value in millisecs). As e result, if we're sending 100 log items, it won't be 200 small `ByteString`s, it will be 1 small `ByteString` (with hostname inside) and 1 big `ByteString` (with 100 items inside).


checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
