### PR TITLE
Update dependencies and Hackage index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-04-01T00:00:00Z
+index-state: 2020-05-15T00:00:00Z
 
 packages:
   contra-tracer
@@ -20,8 +20,8 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: c2f1e6b07885ae709446ecb916973c009f16165c
-  --sha256: 0jpqz9jhr297kxsg65gn0l6qls90ydgrypyaxfq2yv8qjx4vpwr2
+  tag: 3b92f6e936e004753b46f3efabfbbb8539163ea1
+  --sha256: 1hg4xs9aj40xgkm9y8b601x0n4sndj71ppzym34gfq5jgs950lf1
   subdir: Win32-network
 
 constraints:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "141cd02f291e2fd26522d2978d886c06cc65f093",
-        "sha256": "17k6nxizz01grmc94mdi2fwxw8z6ag9zqyzzpypvnzzdkkcazmdy",
+        "rev": "e2a39958269b186b1e83cf2a3fd7f0edadba7652",
+        "sha256": "0b21jkza5crv8shml6xgkyphsyxanimi5m0c8js97w4vb08wg5cz",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/141cd02f291e2fd26522d2978d886c06cc65f093.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e2a39958269b186b1e83cf2a3fd7f0edadba7652.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
-        "branch": "master",
+        "branch": "hkm/recursion-fix",
         "description": "nix scripts shared across projects",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "dfce0e88fee7d5c29fd6f128d02be3594ae39c88",
-        "sha256": "0z9wn2j2ss03w83n298fcapdw9w3cs13w5hrlp3apwjr9iq7x720",
+        "rev": "2ed8569042809a39f5b9e6f6cebc5fb5f5917881",
+        "sha256": "0vz7mb2bm40bvvil159wa2l6gb8943qgs7aycn8j8dvqn726f4im",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/dfce0e88fee7d5c29fd6f128d02be3594ae39c88.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/2ed8569042809a39f5b9e6f6cebc5fb5f5917881.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "0ff5dd333d8f752d86b3a859db882a61c6be2e41",
-        "sha256": "1jsy8m54dmyg6iwz9f761rnnv3n2g7bq0yqlnybmmgk82rvfwifj",
+        "rev": "141cd02f291e2fd26522d2978d886c06cc65f093",
+        "sha256": "17k6nxizz01grmc94mdi2fwxw8z6ag9zqyzzpypvnzzdkkcazmdy",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/0ff5dd333d8f752d86b3a859db882a61c6be2e41.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/141cd02f291e2fd26522d2978d886c06cc65f093.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
   - libsystemd-journal-1.4.4
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: c2f1e6b07885ae709446ecb916973c009f16165c
+    commit: 3b92f6e936e004753b46f3efabfbbb8539163ea1
     subdirs:
         - Win32-network
 


### PR DESCRIPTION
Updating Hackage index-state is required for https://github.com/input-output-hk/cardano-node/issues/1139