### PR TITLE
Add an Ord instance for PrivacyAnnotation

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/LogItem.lhs
@@ -341,7 +341,7 @@ instance FromJSON CommandValue where
 data PrivacyAnnotation =
       Confidential -- confidential information - handle with care
     | Public       -- indifferent - can be public.
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance FromJSON PrivacyAnnotation where
     parseJSON = withText "PrivacyAnnotation" $


### PR DESCRIPTION
This means we can merge many of them using minimum. Useful when we have
to log many things and have to pick a single overall privacy value. We
already have this for severity.