### PR TITLE
CAD-804: Ignore sev filter for errors and metrics.

### DIFF
--- a/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
+++ b/plugins/backend-trace-forwarder/src/Cardano/BM/Backend/TraceForwarder.lhs
@@ -126,7 +126,7 @@ instance (ToJSON a) => IsEffectuator TraceForwarder a where
           case loContent lo of
             LogError _ -> True
             _          -> False
-        errBySev = severity (loMeta lo) == Error
+        errBySev = severity (loMeta lo) >= Error
 
       writeMessageToQueue currentTF' = do
         let queue = tfQueue currentTF'


### PR DESCRIPTION
description
-----------

- [x] Now `TraceForwarder` forwards errors and metrics regardless of their severity level.

Corresponding changes in `cardano-benchmarking`: https://github.com/input-output-hk/cardano-benchmarking/pull/96

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
