### PR TITLE
CAD-1247 set min and max severity filters on scribes

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -98,6 +98,8 @@ prepare_configuration = do
                             , scKind = StdoutSK
                             , scFormat = ScText
                             , scPrivacy = ScPublic
+                            , scMinSev = Notice
+                            , scMaxSev = maxBound
                             , scRotation = Nothing
                             }
                          , ScribeDefinition {
@@ -105,6 +107,8 @@ prepare_configuration = do
                             , scKind = FileSK
                             , scFormat = ScJson
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Just $ RotationParameters
                                               { rpLogLimitBytes = 5000 -- 5kB
                                               , rpMaxAgeHours   = 24
@@ -116,6 +120,8 @@ prepare_configuration = do
                             , scKind = FileSK
                             , scFormat = ScJson
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Just $ RotationParameters
                                               { rpLogLimitBytes = 5000 -- 5kB
                                               , rpMaxAgeHours   = 24
@@ -127,6 +133,8 @@ prepare_configuration = do
                             , scKind = FileSK
                             , scFormat = ScJson
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Just $ RotationParameters
                                               { rpLogLimitBytes = 5000 -- 5kB
                                               , rpMaxAgeHours   = 24
@@ -138,6 +146,21 @@ prepare_configuration = do
                             , scKind = FileSK
                             , scFormat = ScText
                             , scPrivacy = ScPublic
+                            , scMinSev = Info
+                            , scMaxSev = maxBound
+                            , scRotation = Just $ RotationParameters
+                                              { rpLogLimitBytes = 5000 -- 5kB
+                                              , rpMaxAgeHours   = 24
+                                              , rpKeepFilesNum  = 3
+                                              }
+                            }
+                         , ScribeDefinition {
+                              scName = "logs/info.txt"
+                            , scKind = FileSK
+                            , scFormat = ScText
+                            , scPrivacy = ScPublic
+                            , scMinSev = Debug
+                            , scMaxSev = Info
                             , scRotation = Just $ RotationParameters
                                               { rpLogLimitBytes = 5000 -- 5kB
                                               , rpMaxAgeHours   = 24
@@ -149,6 +172,8 @@ prepare_configuration = do
                             , scKind = FileSK
                             , scFormat = ScJson
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Just $ RotationParameters
                                               { rpLogLimitBytes = 50000000 -- 50 MB
                                               , rpMaxAgeHours   = 24
@@ -157,7 +182,7 @@ prepare_configuration = do
                             }
                          ]
 #ifdef LINUX
-    CM.setDefaultScribes c ["StdoutSK::stdout", "JournalSK::example-complex"]
+    CM.setDefaultScribes c ["StdoutSK::stdout", "FileSK::logs/out.txt", "FileSK::logs/info.txt", "JournalSK::example-complex"]
 #else
     CM.setDefaultScribes c ["StdoutSK::stdout"]
 #endif

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -19,7 +19,7 @@ executable example-simple
   -- other-modules:
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
-  ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-T"
+  ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
   build-depends:       base ^>=4.12.0.0
   hs-source-dirs:      simple
   default-language:    Haskell2010
@@ -41,7 +41,7 @@ executable example-counters
   -- other-modules:
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
-  ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-T"
+  ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
   build-depends:       base ^>=4.12.0.0
   hs-source-dirs:      counters
   default-language:    Haskell2010
@@ -94,7 +94,7 @@ executable example-performance
   main-is:             Main.lhs
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
-  ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-T"
+  ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
   other-modules:
   build-depends:       base,
                        iohk-monitoring,
@@ -108,7 +108,7 @@ executable example-acceptor
   main-is:             Main.hs
   default-language:    Haskell2010
   ghc-options:         -threaded
-                       -Wall
+                       -Wall -Werror
                        -rtsopts
                        "-with-rtsopts=-T"
                        -fno-warn-unticked-promoted-constructors

--- a/examples/simple/Main.lhs
+++ b/examples/simple/Main.lhs
@@ -69,6 +69,8 @@ main = do
                             , scFormat = ScText
                             , scKind = StdoutSK
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Nothing
                             }
                          ,  ScribeDefinition {
@@ -76,6 +78,8 @@ main = do
                             , scFormat = ScJson
                             , scKind = StdoutSK
                             , scPrivacy = ScPublic
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             , scRotation = Nothing
                             }
                          ]

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
@@ -35,6 +35,8 @@ defaultConfigStdout = do
                             , scKind = StdoutSK
                             , scPrivacy = ScPublic
                             , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             }
                          ,  ScribeDefinition {
                               scName = "json"
@@ -42,6 +44,8 @@ defaultConfigStdout = do
                             , scKind = StdoutSK
                             , scPrivacy = ScPublic
                             , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             }
                          ]
     CM.setDefaultScribes c ["StdoutSK::text"]
@@ -63,6 +67,8 @@ defaultConfigTesting = do
                             , scKind = DevNullSK
                             , scPrivacy = ScPublic
                             , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             }
                       ]
     CM.setDefaultScribes c ["NullSK::nooutput"]

--- a/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Output.lhs
@@ -25,6 +25,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 
 import           Cardano.BM.Data.Rotation (RotationParameters)
+import           Cardano.BM.Data.Severity
 
 import           GHC.Generics (Generic)
 
@@ -93,6 +94,8 @@ data ScribeDefinition = ScribeDefinition
     , scName     :: Text
     , scPrivacy  :: ScribePrivacy
     , scRotation :: Maybe RotationParameters
+    , scMinSev   :: Severity
+    , scMaxSev   :: Severity
     }
     deriving (Generic, Eq, Ord, Show, ToJSON)
 
@@ -103,12 +106,16 @@ instance FromJSON ScribeDefinition where
         mayFormat  <- o .:? "scFormat"
         mayPrivacy <- o .:? "scPrivacy"
         rotation   <- o .:? "scRotation"
+        mayMinSev  <- o .:? "scMinSev"
+        mayMaxSev  <- o .:? "scMaxSev"
         return $ ScribeDefinition
                     { scKind     = kind
                     , scName     = name
                     , scFormat   = fromMaybe ScJson mayFormat
                     , scPrivacy  = fromMaybe ScPublic mayPrivacy
                     , scRotation = rotation
+                    , scMinSev   = fromMaybe minBound mayMinSev
+                    , scMaxSev   = fromMaybe maxBound mayMaxSev
                     }
     parseJSON invalid = typeMismatch "ScribeDefinition" invalid
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -92,10 +92,12 @@ unitConfigurationStaticRepresentation =
                                     , rpKeepFilesNum  = 10
                                     }
             , setupScribes =
-                [ ScribeDefinition { scName = "stdout"
-                                   , scKind = StdoutSK
+                [ ScribeDefinition { scName     = "stdout"
+                                   , scKind     = StdoutSK
                                    , scFormat   = ScText
-                                   , scPrivacy = ScPublic
+                                   , scPrivacy  = ScPublic
+                                   , scMinSev   = minBound
+                                   , scMaxSev   = maxBound
                                    , scRotation = Nothing }
                 ]
             , defaultScribes = [(StdoutSK, "stdout")]
@@ -146,8 +148,10 @@ unitConfigurationStaticRepresentation =
             , "  test1:"
             , "    value: object1"
             , "setupScribes:"
-            , "- scName: stdout"
+            , "- scMaxSev: Emergency"
+            , "  scName: stdout"
             , "  scRotation: null"
+            , "  scMinSev: Debug"
             , "  scKind: StdoutSK"
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
@@ -230,16 +234,20 @@ unitConfigurationParsedRepresentation = do
             , "    - EKGViewBK"
             , "    - AggregationBK"
             , "setupScribes:"
-            , "- scName: testlog"
+            , "- scMaxSev: Emergency"
+            , "  scName: testlog"
             , "  scRotation:"
             , "    rpLogLimitBytes: 25000000"
             , "    rpKeepFilesNum: 3"
             , "    rpMaxAgeHours: 24"
+            , "  scMinSev: Debug"
             , "  scKind: FileSK"
             , "  scFormat: ScText"
             , "  scPrivacy: ScPrivate"
-            , "- scName: stdout"
+            , "- scMaxSev: Emergency"
+            , "  scName: stdout"
             , "  scRotation: null"
+            , "  scMinSev: Debug"
             , "  scKind: StdoutSK"
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
@@ -347,6 +355,8 @@ unitConfigurationParsed = do
                                     , scFormat   = ScText
                                     , scName     = "testlog"
                                     , scPrivacy  = ScPrivate
+                                    , scMinSev   = minBound
+                                    , scMaxSev   = maxBound
                                     , scRotation = Just $ RotationParameters
                                                     { rpLogLimitBytes = 25000000
                                                     , rpMaxAgeHours   = 24
@@ -358,6 +368,8 @@ unitConfigurationParsed = do
                                     , scFormat = ScText
                                     , scName = "stdout"
                                     , scPrivacy = ScPublic
+                                    , scMinSev   = minBound
+                                    , scMaxSev   = maxBound
                                     , scRotation = Nothing
                                     }
                                 ]

--- a/iohk-monitoring/test/Cardano/BM/Test/Routing.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Routing.lhs
@@ -109,6 +109,8 @@ unit_generic_scribe_backend defaultBackends setBackends defaultScribes setScribe
                             , scFormat = ScText
                             , scPrivacy = ScPublic
                             , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
                             }
                          ]
 

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -722,6 +722,8 @@ unitLoggingPrivate = do
                             , scFormat   = ScText
                             , scName     = pack privateFile
                             , scPrivacy  = ScPrivate
+                            , scMinSev   = minBound
+                            , scMaxSev   = maxBound
                             , scRotation = Nothing
                             }
                          , ScribeDefinition
@@ -729,6 +731,8 @@ unitLoggingPrivate = do
                             , scFormat   = ScText
                             , scName     = pack publicFile
                             , scPrivacy  = ScPublic
+                            , scMinSev   = minBound
+                            , scMaxSev   = maxBound
                             , scRotation = Nothing
                             }
                          ]


### PR DESCRIPTION

description
-----------

- [x] set minimum and maximum severity filters on scribes


checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
