### PR TITLE
CAD-1207: EKG host/port or port only.

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -55,7 +55,7 @@ import           Cardano.BM.Counters (readCounters)
 import           Cardano.BM.Data.Aggregated (Measurable (..))
 import           Cardano.BM.Data.AggregatedKind
 import           Cardano.BM.Data.BackendKind
-import           Cardano.BM.Data.Configuration (RemoteAddr(..))
+import           Cardano.BM.Data.Configuration (Endpoint(..), RemoteAddr(..))
 import           Cardano.BM.Data.Counter
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.MonitoringEval
@@ -254,7 +254,7 @@ prepare_configuration = do
 
     CM.setScribes c "complex.counters" (Just ["StdoutSK::stdout","FileSK::logs/out.json"])
 
-    CM.setEKGport c 12790
+    CM.setEKGBindAddr c $ Just (Endpoint ("localhost", 12790))
     CM.setPrometheusBindAddr c $ Just ("localhost", 12800)
     CM.setGUIport c 13790
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -28,7 +28,7 @@ module Cardano.BM.Configuration
     , CM.updateOption
     , CM.findSubTrace
     , CM.setSubTrace
-    , CM.getEKGport
+    , CM.getEKGBindAddr
     , CM.getGraylogPort
     , CM.getPrometheusBindAddr
     , CM.getGUIport

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -25,9 +25,9 @@ import           Cardano.BM.Data.Configuration
 import           Cardano.BM.Configuration.Model (Configuration (..),
                      ConfigurationInternal (..), getScribes, getCachedScribes,
                      getDefaultBackends, getAggregatedKind, getGUIport,
-                     getEKGport, empty, setDefaultScribes, setScribes, setup,
+                     getEKGBindAddr, empty, setDefaultScribes, setScribes, setup,
                      setDefaultAggregatedKind, setAggregatedKind, setGUIport,
-                     setEKGport, exportConfiguration)
+                     setEKGBindAddr, exportConfiguration)
 import           Cardano.BM.Configuration.Static (defaultConfigStdout)
 import qualified Cardano.BM.Data.Aggregated as Agg
 import           Cardano.BM.Data.AggregatedKind
@@ -105,7 +105,7 @@ unitConfigurationStaticRepresentation =
             , defaultBackends = [ KatipBK ]
             , hasGUI = Just 12789
             , hasGraylog = Just 12788
-            , hasEKG = Just 18321
+            , hasEKG = Just $ Endpoint ("localhost", 18321)
             , hasPrometheus = Just ("localhost", 12799)
             , traceForwardTo = Just (RemotePipe "to")
             , forwardDelay = Just 1000
@@ -155,7 +155,9 @@ unitConfigurationStaticRepresentation =
             , "  scKind: StdoutSK"
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
-            , "hasEKG: 18321"
+            , "hasEKG:"
+            , "- localhost"
+            , "- 18321"
             , "forwardDelay: 1000"
             , "minSeverity: Info"
             , "" -- to force a line feed at the end of the file
@@ -251,7 +253,9 @@ unitConfigurationParsedRepresentation = do
             , "  scKind: StdoutSK"
             , "  scFormat: ScText"
             , "  scPrivacy: ScPublic"
-            , "hasEKG: 12789"
+            , "hasEKG:"
+            , "- 127.0.0.1"
+            , "- 12789"
             , "forwardDelay: 1000"
             , "minSeverity: Info"
             , "" -- to force a line feed at the end of the file
@@ -394,7 +398,7 @@ unitConfigurationParsed = do
                                                 )
                                               )
                                             ]
-        , cgPortEKG           = 12789
+        , cgBindAddrEKG       = Just $ Endpoint ("127.0.0.1", 12789)
         , cgPortGraylog       = 12788
         , cgBindAddrPrometheus = Nothing
         , cgPortGUI           = 0
@@ -444,7 +448,7 @@ unitConfigurationExportStdout = do
     cgMapAggregatedKind  cfgInternal' @?= cgMapAggregatedKind  cfgInternal
     cgDefAggregatedKind  cfgInternal' @?= cgDefAggregatedKind  cfgInternal
     cgMonitors           cfgInternal' @?= cgMonitors           cfgInternal
-    cgPortEKG            cfgInternal' @?= cgPortEKG            cfgInternal
+    cgBindAddrEKG        cfgInternal' @?= cgBindAddrEKG        cfgInternal
     cgPortGraylog        cfgInternal' @?= cgPortGraylog        cfgInternal
     cgBindAddrPrometheus cfgInternal' @?= cgBindAddrPrometheus cfgInternal
     cgPortGUI            cfgInternal' @?= cgPortGUI            cfgInternal
@@ -497,8 +501,8 @@ unitConfigurationOps = do
     setAggregatedKind configuration "name1" $ Just StatsAK
     name1AggregatedKind <- getAggregatedKind configuration "name1"
 
-    setEKGport configuration 11223
-    ekgPort <- getEKGport configuration
+    setEKGBindAddr configuration (Just $ Endpoint ("localhost", 11223))
+    ekgBindAddr <- getEKGBindAddr configuration
 
     setGUIport configuration 1080
     guiPort <- getGUIport configuration
@@ -512,8 +516,8 @@ unitConfigurationOps = do
     assertBool "Specific name aggregated kind" $
         name1AggregatedKind == StatsAK
 
-    assertBool "Set EKG port" $
-        ekgPort == 11223
+    assertBool "Set EKG host/port" $
+        ekgBindAddr == (Just $ Endpoint ("localhost", 11223))
 
     assertBool "Set GUI port" $
         guiPort == 1080

--- a/iohk-monitoring/test/config.yaml
+++ b/iohk-monitoring/test/config.yaml
@@ -22,7 +22,7 @@ defaultBackends:
 # if wanted, the GUI is listening on this port:
 # hasGUI: 18321
 
-# if wanted, the EKG interface is listening on this port:
+# if wanted, the EKG interface is listening on this host/port (host is "127.0.0.1" if undefined):
 hasEKG: 12789
 
 # if wanted, we send log items to Graylog on this port:


### PR DESCRIPTION
description
-----------

Previously, only EKG port could be defined in the configuration, and host was hardcoded as `"127.0.0.1"`. Now it's possible to specify the host as well (as for `hasPrometheus`). But for backward compatibility `hasEKG` still may contain the port only, in this case `"127.0.0.1"` will be used as a host. So now it's possible to specify it like this:

```
hasEKG: 12789
```

or like this:

```
hasEKG:
- "198.51.100.2"
- 12789
```

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [x] documentation added
- [ ] link to an issue
- [x] add milestone (the current sprint)
