### PR TITLE
Replace dependency on lens with microlens

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -104,7 +104,6 @@ library
                        directory,
                        filepath,
                        katip,
-                       microlens,
                        mtl,
                        network,
                        safe,

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -104,7 +104,7 @@ library
                        directory,
                        filepath,
                        katip,
-                       lens,
+                       microlens,
                        mtl,
                        network,
                        safe,

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -34,7 +34,6 @@ import           Control.Concurrent.MVar (MVar, modifyMVar_, readMVar,
                      newMVar, withMVar)
 import           Control.Exception.Safe (catchIO)
 import           Control.Monad (foldM, forM_, unless, when, void)
-import           Control.Lens ((^.))
 import           Data.Aeson (FromJSON, ToJSON, Result (Success), Value (..),
                      encode, fromJSON, toJSON)
 import           Data.Aeson.Text (encodeToLazyText)
@@ -53,6 +52,7 @@ import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
 import           GHC.Conc (atomically)
 import           GHC.IO.Handle (hDuplicate)
+import           Lens.Micro ((^.))
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory)
 import           System.IO (BufferMode (LineBuffering), Handle, hClose,

--- a/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Log.lhs
@@ -52,7 +52,6 @@ import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Time.Format (defaultTimeLocale, formatTime)
 import           GHC.Conc (atomically)
 import           GHC.IO.Handle (hDuplicate)
-import           Lens.Micro ((^.))
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath (takeDirectory)
 import           System.IO (BufferMode (LineBuffering), Handle, hClose,
@@ -275,16 +274,16 @@ passStrx backend katip (LogObject loname lometa loitem) = do
                         let itemTime = tstamp lometa
                         let localname = [loname]
                         let itemKatip = K.Item {
-                                  _itemApp       = env ^. KC.logEnvApp
-                                , _itemEnv       = env ^. KC.logEnvEnv
+                                  _itemApp       = KC._logEnvApp env
+                                , _itemEnv       = KC._logEnvEnv env
                                 , _itemSeverity  = sev2klog sev
                                 , _itemThread    = threadIdText
                                 , _itemHost      = unpack $ hostname lometa
-                                , _itemProcess   = env ^. KC.logEnvPid
+                                , _itemProcess   = KC._logEnvPid env
                                 , _itemPayload   = payload
                                 , _itemMessage   = ""
                                 , _itemTime      = itemTime
-                                , _itemNamespace = env ^. KC.logEnvApp <> K.Namespace localname
+                                , _itemNamespace = KC._logEnvApp env <> K.Namespace localname
                                 , _itemLoc       = Nothing
                                 }
                         void $ atomically $ KC.tryWriteTBQueue shChan (KC.NewItem itemKatip)
@@ -327,16 +326,16 @@ passText backend katip (LogObject loname lometa loitem) = do
                         let itemTime = tstamp lometa
                         let localname = [loname]
                         let itemKatip = K.Item {
-                                  _itemApp       = env ^. KC.logEnvApp
-                                , _itemEnv       = env ^. KC.logEnvEnv
+                                  _itemApp       = KC._logEnvApp env
+                                , _itemEnv       = KC._logEnvEnv env
                                 , _itemSeverity  = sev2klog sev
                                 , _itemThread    = threadIdText
                                 , _itemHost      = unpack $ hostname lometa
-                                , _itemProcess   = env ^. KC.logEnvPid
+                                , _itemProcess   = KC._logEnvPid env
                                 , _itemPayload   = ()
                                 , _itemMessage   = K.logStr msg
                                 , _itemTime      = itemTime
-                                , _itemNamespace = env ^. KC.logEnvApp <> K.Namespace localname
+                                , _itemNamespace = KC._logEnvApp env <> K.Namespace localname
                                 , _itemLoc       = Nothing
                                 }
                         void $ atomically $ KC.tryWriteTBQueue shChan (KC.NewItem itemKatip)


### PR DESCRIPTION
description
-----------

Replace dependency on `lens` with `microlens` to avoid building the Kmettoverse.

I checked with `cabal-plan info` that after this change, there is no more dependency on `lens`, only `microlens`, which a few dependencies of this repo already depend on.


checklist
---------

- [X] compiles (`cabal v2-build` or `stack build`)
- [X] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
