### PR TITLE
CAD-1208: Prometheus JSON output.

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -268,6 +268,7 @@ output could also be forwarded using a pipe:
 \begin{code}
     CM.setForwardTo c (Just $ RemoteSocket "127.0.0.1" "42999")
     CM.setTextOption c "forwarderMinSeverity" "Warning"  -- sets min severity filter in forwarder
+    CM.setTextOption c "prometheusOutput" "json"  -- Prometheus' output in JSON-format
 
     CM.setForwardDelay c (Just 1000)
 

--- a/plugins/backend-ekg/src/Cardano/BM/Backend/EKGView.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/EKGView.lhs
@@ -48,7 +48,7 @@ import           Paths_iohk_monitoring (version)
 import           Cardano.BM.Backend.ProcessQueue (processQueue)
 import           Cardano.BM.Backend.Prometheus (spawnPrometheus)
 import           Cardano.BM.Configuration (Configuration, getEKGBindAddr,
-                     getPrometheusBindAddr, testSubTrace)
+                     getPrometheusBindAddr, getTextOption, testSubTrace)
 import           Cardano.BM.Data.Aggregated
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.Configuration (Endpoint (..))
@@ -247,10 +247,11 @@ instance (ToJSON a, FromJSON a) => IsBackend EKGView a where
         -- thread, wrapped in ExceptionInLinkedThread.
         Async.link dispatcher
         prometheusBindAddr <- getPrometheusBindAddr config
+        prometheusOutput <- getTextOption config "prometheusOutput"
         prometheusDispatcher <-
                 case prometheusBindAddr of
                   Just (host, port) -> do
-                    pd <- spawnPrometheus ehdl (fromString host) port
+                    pd <- spawnPrometheus ehdl (fromString host) port prometheusOutput
                       `catch` mkHandler EKGPrometheusStartupError
                     Async.link pd
                     return (Just pd)

--- a/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
@@ -5,6 +5,10 @@
 %if style == newcode
 \begin{code}
 
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiWayIf #-}
+
 module Cardano.BM.Backend.Prometheus
     ( spawnPrometheus
     ) where
@@ -12,11 +16,17 @@ module Cardano.BM.Backend.Prometheus
 import qualified Control.Concurrent.Async as Async
 import           Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson as A
+import           Data.Aeson ((.=))
 import           Data.ByteString.Builder
 import           Data.ByteString.Char8 (ByteString)
-import           Data.Text (Text, replace)
+import           Data.List (find, partition)
+import           Data.Maybe (fromJust)
+import           Data.Text (Text)
+import qualified Data.Text as T
 import           Data.Text.Encoding (encodeUtf8)
 import           Data.Text.Read (double)
+import           GHC.Generics
 import           Snap.Core (Snap, route, writeLBS)
 import           Snap.Http.Server (Config, ConfigLog (..), defaultConfig, setAccessLog,
                      setBind, setErrorLog, setPort, simpleHttpServe)
@@ -30,8 +40,33 @@ import qualified System.Remote.Monitoring as EKG
 \label{code:spawnPrometheus}\index{spawnPrometheus}
 \begin{code}
 
-spawnPrometheus :: EKG.Server -> ByteString -> Int -> IO (Async.Async ())
-spawnPrometheus ekg host port = Async.async $
+data MetricsGroup = MetricsGroup
+    { namespace :: !Text
+    , metrics   :: ![Metric]
+    } deriving (Generic, A.ToJSON)
+
+data Metric
+    = NoMetric
+    | Metric
+        { mName  :: !Text
+        , mType  :: !Text
+        , mValue :: !Number
+        }
+
+instance A.ToJSON Metric where
+    toJSON NoMetric = A.Null
+    toJSON (Metric n t v) = A.object ["name" .= n, "type" .= t, "value" .= v]
+
+data Number
+    = NumberInt Integer
+    | NumberReal Double
+
+instance A.ToJSON Number where
+    toJSON (NumberInt i)  = A.Number $ fromInteger i
+    toJSON (NumberReal r) = A.Number $ fromRational (toRational r)
+
+spawnPrometheus :: EKG.Server -> ByteString -> Int -> Maybe Text -> IO (Async.Async ())
+spawnPrometheus ekg host port prometheusOutput = Async.async $
     simpleHttpServe config site
   where
     config :: Config Snap a
@@ -42,8 +77,17 @@ spawnPrometheus ekg host port = Async.async $
     webhandler :: EKG.Server -> Snap ()
     webhandler srv = do
         samples <- liftIO $ sampleAll $ EKG.serverMetricStore srv
-        writeLBS . toLazyByteString . renderSamples $ HM.toList samples
+        let output = case prometheusOutput of
+                         Nothing     -> renderSimpleOutput samples
+                         Just "json" -> renderJSONOutput samples
+                         Just _      -> renderSimpleOutput samples
+        writeLBS output
         pure ()
+
+    -- Simple output: key value.
+
+    renderSimpleOutput = toLazyByteString . renderSamples . HM.toList
+
     renderSamples :: [(Text, Value)] -> Builder
     renderSamples [] = mempty
     renderSamples samples = mconcat
@@ -61,9 +105,67 @@ spawnPrometheus ekg host port = Async.async $
         <> charUtf8 ' '
         <> bld
         <> charUtf8 '\n'
-    prepareName nm = encodeUtf8 $ replace " " "_" $ replace "-" "_" $ replace "." "_" nm
+    prepareName nm = encodeUtf8 $ T.replace " " "_" $ T.replace "-" "_" $ T.replace "." "_" nm
     isFloat v = case double v of
         Right (_n, "") -> True  -- only floating point number parsed, no leftover
         _ -> False
 
+    -- JSON output
+
+    renderJSONOutput samples =
+        let rtsNamespace = "rts.gc"
+            (rtsSamples, otherSamples) = partition (\(sk, _) -> rtsNamespace `T.isPrefixOf` sk) $ HM.toList samples
+            rtsMetrics = extractRtsGcMetrics rtsNamespace rtsSamples
+            otherMetrics = extractOtherMetrics otherSamples
+        in A.encode [rtsMetrics, otherMetrics]
+
+    -- rts.gc metrics are always here because they are predefined in ekg-core,
+    -- so we can group them.
+    extractRtsGcMetrics :: Text -> [(Text, Value)] -> MetricsGroup
+    extractRtsGcMetrics ns samples = MetricsGroup
+        { namespace = ns
+        , metrics =
+            [ case sv of
+                Counter c -> intMetric sk c
+                Gauge g   -> intMetric sk g
+                _         -> NoMetric -- rts.gc can contain Counter or Gauge only.
+            | (sk, sv) <- samples
+            ]
+        }
+      where
+        intMetric sk v =
+            Metric { mName  = maybe "" id $ T.stripPrefix (ns <> ".") sk
+                   , mType  = "int" -- All values are Int64.
+                   , mValue = NumberInt (fromIntegral v)
+                   }
+
+    -- We cannot make any assumptions about the format of 'sk' in other samples,
+    -- so group other samples into 'common' group.
+    extractOtherMetrics :: [(Text, Value)] -> MetricsGroup
+    extractOtherMetrics samples = MetricsGroup
+        { namespace = "common"
+        , metrics =
+            [ case sv of
+                Counter c -> mkMetric sk $ NumberInt (fromIntegral c)
+                Gauge g   -> mkMetric sk $ NumberInt (fromIntegral g)
+                Label l   -> case double l of
+                                 Left _       -> NoMetric
+                                 Right (r, _) -> mkMetric sk $ NumberReal r
+                _         -> NoMetric
+            | (sk, sv) <- samples
+            ]
+        }
+      where
+        mkMetric sk number =
+            let (withoutType, typeSuffix) = stripTypeSuffix sk number
+            in Metric { mName = withoutType, mType = typeSuffix, mValue = number }
+        stripTypeSuffix sk number =
+            let types = ["us", "ns", "s", "B", "int", "real"]
+                parts = T.splitOn "." sk
+                typeSuffix = if not . null $ parts then last parts else ""
+            in if typeSuffix `elem` types
+                   then (fromJust $ T.stripSuffix ("." <> typeSuffix) sk, typeSuffix)
+                   else case number of
+                            NumberInt _  -> (sk, "int")
+                            NumberReal _ -> (sk, "real")
 \end{code}


### PR DESCRIPTION
description
-----------

Previously Prometheus' output was ini-like formatted, for example:

```
...
rts_gc_gc_wall_ms 38
cardano_node_metrics_Mem_resident_int 17748
rts_gc_mutator_cpu_ms 316
rts_gc_peak_megabytes_allocated 50
...
```

Now the output is in JSON-format which is easier to parse. An example:

```
[
  {
    "metrics": [
      {
        "value": 0,
        "name": "par_max_bytes_copied",
        "type": "int"
      },
      {
        "value": 0,
        "name": "par_avg_bytes_copied",
        "type": "int"
      },
      {
        "value": 1,
        "name": "init_cpu_ms",
        "type": "int"
      },
      {
        "value": 7308376,
        "name": "bytes_allocated",
        "type": "int"
      },
      {
        "value": 6,
        "name": "num_bytes_usage_samples",
        "type": "int"
      },
      {
        "value": 105264,
        "name": "current_bytes_slop",
        "type": "int"
      },
      {
        "value": 105264,
        "name": "max_bytes_slop",
        "type": "int"
      },
      {
        "value": 0,
        "name": "par_tot_bytes_copied",
        "type": "int"
      },
      {
        "value": 3068968,
        "name": "cumulative_bytes_used",
        "type": "int"
      },
      {
        "value": 13,
        "name": "gc_wall_ms",
        "type": "int"
      },
      {
        "value": 34,
        "name": "cpu_ms",
        "type": "int"
      }
    ],
    "namespace": "rts.gc"
  }
  ...
]
```

Please note that only `rts.gc`-metrics are grouped in one group `"rts.gc"`. All other metrics can have different names and we can not make any assumptions about the format of these names. So all other metrics are grouped in `"common"` group. An example:

```
{
    "metrics": [
      {
        "value": 0.1,
        "name": "iohk-monitoring version",
        "type": "real"
      },
      {
        "value": 26.30240838783037,
        "name": "complex.random.rr",
        "type": "real"
      },
      {
        "value": 1596470035685,
        "name": "ekg.server_timestamp_ms",
        "type": "int"
      },
      {
        "value": 37.711116781794196,
        "name": "complex.#aggregation.complex.random.ewma.rr.rr.avg",
        "type": "real"
      }
    ],
    "namespace": "common"
  }
```  

Please note that it's possible to choose a format using this option:

```
CM.setTextOption c "prometheusOutput" "json"  -- Prometheus' output in JSON-format
```

If this option is not specified in the configuration - an old format will be used.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
