### PR TITLE
CAD-1430 optional reporting of elided messages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 3b92f6e936e004753b46f3efabfbbb8539163ea1
-  --sha256: 1hg4xs9aj40xgkm9y8b601x0n4sndj71ppzym34gfq5jgs950lf1
+  tag: fbfae1dbed1f22ba4cceacd881e60a2bc25a39d3
+  --sha256: 1sykn9vnbccv2z4kjdf78y65wn4ljqfamlb9xwjv5y4d07h5r6yj
   subdir: Win32-network
 
 constraints:

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -50,7 +50,7 @@ library
                        Cardano.BM.Data.Trace
                        Cardano.BM.Data.Tracer
                        Cardano.BM.Data.Transformers
-                       Cardano.BM.ElidingTracer
+                       Cardano.BM.Internal.ElidingTracer
                        Cardano.BM.Tracing
 
                        Cardano.BM.Backend.Log

--- a/iohk-monitoring/src/Cardano/BM/Internal/ElidingTracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Internal/ElidingTracer.lhs
@@ -1,6 +1,12 @@
 
-\subsection{Cardano.BM.ElidingTracer}
-\label{code:Cardano.BM.ElidingTracer}
+\subsection{Cardano.BM.Internal.ElidingTracer}
+\label{code:Cardano.BM.Internal.ElidingTracer}
+
+This module is marked \emph{internal} as its use is risky and should only be included
+if one has tested the implemented instances thoroughly.
+
+Disclaimer: Use at your own risk. Eliding of messages can result in the irrevocable removal
+of traced values.
 
 %if style == newcode
 \begin{code}
@@ -8,7 +14,7 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE LambdaCase        #-}
 
-module Cardano.BM.ElidingTracer
+module Cardano.BM.Internal.ElidingTracer
     (
       ElidingTracer (..)
     , defaultelidedreporting
@@ -39,12 +45,14 @@ class ElidingTracer a where
 
 This predicate is |True| for message types for which eliding is enabled. Needs to be
 overwritten in instances of |ElidingTracer|.
+\label{code:doelide}\index{ElidingTracer!doelide}
 \begin{code}
   doelide :: a -> Bool
 \end{code}
 
 The predicate to determine if two messages are |equivalent|. This needs to be
 overwritten in instances of |ElidingTracer|.
+\label{code:isEquivalent}\index{ElidingTracer!isEquivalent}
 \begin{code}
   isEquivalent :: a -> a -> Bool
 \end{code}
@@ -58,6 +66,10 @@ Create a new state |MVar|.
 \end{code}
 
 Internal state transitions.
+\label{code:starteliding}\index{ElidingTracer!starteliding}
+\label{code:conteliding}\index{ElidingTracer!conteliding}
+\label{code:stopeliding}\index{ElidingTracer!stopeliding}
+\label{code:reportelided}\index{ElidingTracer!reportelided}
 \begin{code}
   starteliding :: (ToObject t, Transformable t IO a)
                => TracingVerbosity -> Trace IO t
@@ -135,6 +147,14 @@ the main logic of eliding messages.
         stopeliding tverb tr ev s
 
 \end{code}
+
+\subsubsection{Tracing a summary messages after eliding}
+\label{code:defaultelidedreporting}\index{defaultelidedreporting}
+
+This is the default implementation of tracing a summary message after eliding stopped.
+It simply outputs the internal counter.
+In cases where this state is used for other purposes than counting messages, the
+\ref{reportelided} function should be implemented in the \ref{ElidingTracer} instance.
 
 \begin{code}
 defaultelidedreporting :: (ToObject t, Transformable t IO a)

--- a/iohk-monitoring/test/Cardano/BM/Test/Tracer.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Tracer.lhs
@@ -21,7 +21,7 @@ import           Data.Text (Text, pack, unpack)
 import           Cardano.BM.Configuration.Static
 import           Cardano.BM.Configuration (Configuration)
 import           Cardano.BM.Configuration.Model (setSubTrace)
-import           Cardano.BM.ElidingTracer
+import           Cardano.BM.Internal.ElidingTracer
 import           Cardano.BM.Data.Aggregated (Measurable(PureI))
 import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,7 +28,7 @@ extra-deps:
   - libsystemd-journal-1.4.4
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 3b92f6e936e004753b46f3efabfbbb8539163ea1
+    commit: fbfae1dbed1f22ba4cceacd881e60a2bc25a39d3
     subdirs:
         - Win32-network
 


### PR DESCRIPTION

description
-----------

- [x] can redefine traced message at end of eliding (required for PR https://github.com/input-output-hk/cardano-node/pull/1678)


checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
