### PR TITLE
Prepare GHC 8.10 compatibility

### DIFF
--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -20,7 +20,6 @@ executable example-simple
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
   ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
-  build-depends:       base ^>=4.12.0.0
   hs-source-dirs:      simple
   default-language:    Haskell2010
   build-depends:       base,
@@ -42,7 +41,6 @@ executable example-counters
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
   ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
-  build-depends:       base ^>=4.12.0.0
   hs-source-dirs:      counters
   default-language:    Haskell2010
   build-depends:       base,

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -70,10 +70,8 @@ import           Control.Applicative (Alternative ((<|>)))
 import           Control.Concurrent.MVar (MVar, newMVar, readMVar,
                      modifyMVar_)
 import           Control.Monad (when)
-import           Data.Aeson ((.:))
-import           Data.Aeson.Types (parseMaybe)
 import qualified Data.HashMap.Strict as HM
-import           Data.Maybe (maybe, catMaybes, fromMaybe)
+import           Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Text as T
 import           Data.Text (Text, pack, unpack)
 import qualified Data.Vector as Vector

--- a/iohk-monitoring/src/Cardano/BM/Counters/Linux.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Counters/Linux.lhs
@@ -16,7 +16,6 @@ import           Data.Foldable (foldrM)
 import           Data.Maybe (catMaybes)
 import           Data.Text (Text, pack)
 import           System.FilePath.Posix ((</>))
-import           System.IO (FilePath)
 import           System.Posix.Files (getFileStatus,fileMode,ownerReadMode,
                      intersectFileModes)
 import           System.Posix.Process (getProcessID)

--- a/iohk-monitoring/src/Cardano/BM/Setup.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Setup.lhs
@@ -25,7 +25,6 @@ import           Control.Exception.Safe (MonadMask, bracket)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.Aeson (FromJSON, ToJSON)
 import           Data.Text (Text)
-import           System.IO (FilePath)
 
 import qualified Cardano.BM.Configuration as Config
 import           Cardano.BM.Data.Tracer (ToObject)

--- a/iohk-monitoring/src/Cardano/BM/Trace.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Trace.lhs
@@ -36,7 +36,6 @@ import qualified Control.Concurrent.STM.TVar as STM
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Control.Monad.STM as STM
 import           Data.Aeson.Text (encodeToLazyText)
-import           Data.Monoid ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import           Data.Text.Lazy (toStrict)

--- a/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Configuration.lhs
@@ -14,7 +14,6 @@ module Cardano.BM.Test.Configuration (
 import           Prelude hiding (Ordering (..))
 
 import           Control.Concurrent.MVar (readMVar)
-import           Data.Aeson.Types (Value (..))
 import           Data.ByteString (intercalate)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V

--- a/iohk-monitoring/test/Cardano/BM/Test/Tracer.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Tracer.lhs
@@ -15,7 +15,6 @@ module Cardano.BM.Test.Tracer (
 
 import qualified Control.Concurrent.STM.TVar as STM
 import           Control.Monad (forM_, void, when)
-import           Data.Functor.Contravariant (Contravariant (..))
 import           Data.Text (Text, pack, unpack)
 
 import           Cardano.BM.Configuration.Static

--- a/plugins/backend-ekg/lobemo-backend-ekg.cabal
+++ b/plugins/backend-ekg/lobemo-backend-ekg.cabal
@@ -19,7 +19,7 @@ library
   other-modules:       Cardano.BM.Backend.Prometheus
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base < 4.13,
+  build-depends:       base < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-trace-acceptor/src/Cardano/BM/Backend/TraceAcceptor.lhs
+++ b/plugins/backend-trace-acceptor/src/Cardano/BM/Backend/TraceAcceptor.lhs
@@ -38,7 +38,6 @@ import qualified System.IO as IO
 
 import           Cardano.BM.Configuration
 import           Cardano.BM.Data.Backend
-import           Cardano.BM.Data.BackendKind (BackendKind(TraceAcceptorBK))
 import           Cardano.BM.Data.Configuration (RemoteAddr(..), RemoteAddrNamed(..))
 import           Cardano.BM.Data.LogItem
                    ( LOContent (LogError), LOMeta (..), LogObject (..)
@@ -180,7 +179,7 @@ clientThread
   -> Trace.Trace IO a
   -> Handle
   -> IO ()
-clientThread config sbtrace h = handleError TraceAcceptorClientThreadError pProc
+clientThread _config sbtrace h = handleError TraceAcceptorClientThreadError pProc
   where
     {-@ lazy pProc @-}
     pProc :: IO ()


### PR DESCRIPTION
description
-----------

* Bump upper bounds on `base` to be compatible with GHC 8.10
* Remove redundant imports as detected by GHC 8.10

  Since 8.6.5, GHC has become better in detecting redundant imports. GHC 8.10.2 has marked these as redundant, so remove them. This still compiles with GHC 8.6.5, because they *already were* redundant, GHC just didn't realise it.

checklist
---------

- [X] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
