### PR TITLE
Configuration: add setAcceptAt.

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -38,6 +38,7 @@ module Cardano.BM.Configuration.Model
     , getTextOption
     , inspectSeverity
     , minSeverity
+    , setAcceptAt
     , setAggregatedKind
     , setBackends
     , setCachedScribes
@@ -335,6 +336,11 @@ setGUIport configuration port =
 
 getAcceptAt :: Configuration -> IO (Maybe [RemoteAddrNamed])
 getAcceptAt = fmap cgAcceptAt . readMVar . getCG
+
+setAcceptAt :: Configuration -> Maybe [RemoteAddrNamed] -> IO ()
+setAcceptAt cf mran =
+    modifyMVar_ (getCG cf) $ \cg ->
+        return cg { cgAcceptAt = mran }
 
 getForwardTo :: Configuration -> IO (Maybe RemoteAddr)
 getForwardTo = fmap cgForwardTo . readMVar . getCG


### PR DESCRIPTION
description
-----------

Add the missing `setAcceptAt` function, to be able to form the configuration (with acceptors) programmatically. 

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
