### PR TITLE
Ghc 8.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ cabal.project.local~
 .dir-locals.el
 
 tags
+
+/.vscode
+

--- a/cabal.project
+++ b/cabal.project
@@ -20,8 +20,8 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 64351aaa3b27fd5a28fc7d1f9c48f9e5a815dab2
-  --sha256: 10zw06rnfl39kw43pkv1h1x0lwd768bvs6ddn9y92vs9yafw1hlz
+  tag: 7789e638776b1f4049dab623aadf7961c2023b4a
+  --sha256: 0gr2lwn53p8s5vml6sz5bvfwfzv67kli29qb5sv0xb42kv01a73m
   subdir: Win32-network
 
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -20,15 +20,21 @@ package iohk-monitoring
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: fbfae1dbed1f22ba4cceacd881e60a2bc25a39d3
-  --sha256: 1sykn9vnbccv2z4kjdf78y65wn4ljqfamlb9xwjv5y4d07h5r6yj
+  tag: 64351aaa3b27fd5a28fc7d1f9c48f9e5a815dab2
+  --sha256: 10zw06rnfl39kw43pkv1h1x0lwd768bvs6ddn9y92vs9yafw1hlz
   subdir: Win32-network
+
+source-repository-package
+  type: git
+  location: https://github.com/CodiePP/libsystemd-journal.git
+  tag: 4371464d5ae3fe1df4e3e77ab33156ad2d3bf1bd
+  --sha256: 1sqcz2lachr8mwmfl4g9ypp1w4rsba707kysb86x0x614ghd48kx
 
 constraints:
   ip < 1.5,
   hedgehog >= 1.0,
   bimap >= 0.4.0,
-  libsystemd-journal >= 1.4.4
+  libsystemd-journal >= 1.5.0
 
 package comonad
   flags: -test-doctests

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-07-15T00:00:00Z
+index-state: 2020-09-15T00:00:00Z
 
 packages:
   contra-tracer

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -20,6 +20,7 @@ executable example-simple
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
   ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
+  build-depends:       base >= 4.12 && < 4.15
   hs-source-dirs:      simple
   default-language:    Haskell2010
   build-depends:       base,
@@ -41,6 +42,7 @@ executable example-counters
   default-extensions:  OverloadedStrings
   other-extensions:    CPP, FlexibleInstances, MultiParamTypeClasses, ScopedTypeVariables
   ghc-options:         -threaded -Wall -Werror -O2 "-with-rtsopts=-T"
+  build-depends:       base >= 4.12 && < 4.15
   hs-source-dirs:      counters
   default-language:    Haskell2010
   build-depends:       base,

--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -91,7 +91,7 @@ library
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings
   other-extensions:    OverloadedStrings
-  build-depends:       base >= 4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        contra-tracer,
                        aeson >= 1.4.2,
                        array,

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Model.lhs
@@ -71,7 +71,6 @@ import           Control.Concurrent.MVar (MVar, newMVar, readMVar,
                      modifyMVar_)
 import           Control.Monad (when)
 import qualified Data.HashMap.Strict as HM
-import           Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Text as T
 import           Data.Text (Text, pack, unpack)
 import qualified Data.Vector as Vector
@@ -88,6 +87,9 @@ import           Cardano.BM.Data.Output (ScribeDefinition (..), ScribeId,
 import           Cardano.BM.Data.Rotation (RotationParameters (..))
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.SubTrace
+
+import qualified Data.Maybe as M
+
 
 \end{code}
 %endif
@@ -525,7 +527,7 @@ setupFromRepresentation r = do
     fillRotationParams defaultRotation = map $ \sd ->
         if scKind sd == FileSK
         then
-            sd { scRotation = maybe defaultRotation Just (scRotation sd) }
+            sd { scRotation = M.maybe defaultRotation Just (scRotation sd) }
         else
             -- stdout, stderr, /dev/null and systemd cannot be rotated
             sd { scRotation = Nothing }
@@ -533,7 +535,7 @@ setupFromRepresentation r = do
     parseBackendMap Nothing = HM.empty
     parseBackendMap (Just hmv) = HM.map mkBackends hmv
       where
-        mkBackends (Array bes) = catMaybes $ map mkBackend $ Vector.toList bes
+        mkBackends (Array bes) = M.catMaybes $ map mkBackend $ Vector.toList bes
         mkBackends _ = []
         mkBackend :: Value -> Maybe BackendKind
         mkBackend = parseMaybe parseJSON
@@ -541,7 +543,7 @@ setupFromRepresentation r = do
     parseScribeMap Nothing = HM.empty
     parseScribeMap (Just hmv) = HM.map mkScribes hmv
       where
-        mkScribes (Array scs) = catMaybes $ map mkScribe $ Vector.toList scs
+        mkScribes (Array scs) = M.catMaybes $ map mkScribe $ Vector.toList scs
         mkScribes (String s) = [(s :: ScribeId)]
         mkScribes _ = []
         mkScribe :: Value -> Maybe ScribeId
@@ -709,7 +711,7 @@ findRootSubTrace config loggername =
 
 testSubTrace :: Configuration -> LoggerName -> LogObject a -> IO (Maybe (LogObject a))
 testSubTrace config loggername lo = do
-    subtrace <- fromMaybe Neutral <$> findRootSubTrace config loggername
+    subtrace <- M.fromMaybe Neutral <$> findRootSubTrace config loggername
     return $ testSubTrace' lo subtrace
   where
     testSubTrace' :: LogObject a -> SubTrace -> Maybe (LogObject a)

--- a/iohk-monitoring/src/Cardano/BM/Counters/Windows.hsc
+++ b/iohk-monitoring/src/Cardano/BM/Counters/Windows.hsc
@@ -11,7 +11,6 @@ module Cardano.BM.Counters.Windows
 #ifdef ENABLE_OBSERVABLES
 import           Data.Foldable (foldrM)
 import           Data.Word (Word64)
--- import           Foreign.C.String
 import           Foreign.C.Types
 import           Foreign.Marshal.Alloc
 import           Foreign.Ptr

--- a/nix/sources.
+++ b/nix/sources.
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2a15520113cf2d00ff85beeb1db325463f27da2a",
-        "sha256": "0np1z3j86iiqm3z3dz2wjh7xjj9qvdalppls73k7vyifbsm6pl42",
+        "rev": "d20a23b7ed71842283bdda5b8a53e7883cb353f4",
+        "sha256": "1psa48dl0l28sk41m70kmii1mgzarqsvra90bm0hpmmmp94al70q",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/2a15520113cf2d00ff85beeb1db325463f27da2a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/d20a23b7ed71842283bdda5b8a53e7883cb353f4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/plugins/backend-aggregation/lobemo-backend-aggregation.cabal
+++ b/plugins/backend-aggregation/lobemo-backend-aggregation.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-editor/lobemo-backend-editor.cabal
+++ b/plugins/backend-editor/lobemo-backend-editor.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-ekg/lobemo-backend-ekg.cabal
+++ b/plugins/backend-ekg/lobemo-backend-ekg.cabal
@@ -19,7 +19,7 @@ library
   other-modules:       Cardano.BM.Backend.Prometheus
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base,
+  build-depends:       base >= 4.11 && < 4.15,
                        aeson,
                        async,
                        bytestring,

--- a/plugins/backend-graylog/lobemo-backend-graylog.cabal
+++ b/plugins/backend-graylog/lobemo-backend-graylog.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-monitoring/lobemo-backend-monitoring.cabal
+++ b/plugins/backend-monitoring/lobemo-backend-monitoring.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-trace-acceptor/lobemo-backend-trace-acceptor.cabal
+++ b/plugins/backend-trace-acceptor/lobemo-backend-trace-acceptor.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/backend-trace-forwarder/lobemo-backend-trace-forwarder.cabal
+++ b/plugins/backend-trace-forwarder/lobemo-backend-trace-forwarder.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        async,

--- a/plugins/scribe-systemd/lobemo-scribe-systemd.cabal
+++ b/plugins/scribe-systemd/lobemo-scribe-systemd.cabal
@@ -19,7 +19,7 @@ library
   -- other-modules:
   -- other-extensions:
   default-extensions:  OverloadedStrings
-  build-depends:       base >=4.11,
+  build-depends:       base >= 4.11 && < 4.15,
                        iohk-monitoring,
                        aeson,
                        bytestring,

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,7 +33,7 @@ extra-deps:
   - katip-0.8.4.0
 
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: 64351aaa3b27fd5a28fc7d1f9c48f9e5a815dab2
+    commit: 7789e638776b1f4049dab623aadf7961c2023b4a
     subdirs:
         - Win32-network
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -32,12 +32,15 @@ extra-deps:
   - time-units-1.0.0
   - katip-0.8.4.0
 
-  - libsystemd-journal-1.4.4
-
   - git: https://github.com/input-output-hk/ouroboros-network
-    commit: fbfae1dbed1f22ba4cceacd881e60a2bc25a39d3
+    commit: 64351aaa3b27fd5a28fc7d1f9c48f9e5a815dab2
     subdirs:
         - Win32-network
+
+  - git: https://github.com/CodiePP/libsystemd-journal
+    commit: 4371464d5ae3fe1df4e3e77ab33156ad2d3bf1bd
+    subdirs:
+        - .
 
 nix:
   # GHC 8.6.5


### PR DESCRIPTION
## description

Changes to support `ghc-8.10.2` in preparation for `ghc-8.10.2` support in `cardano-node.

Changes:
* Adjusting bounds for `base`
* Adjust imports and using qualified imports in select cases

checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
