### PR TITLE
Fix build for MacOS

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,18 +17,14 @@ packages:
 package iohk-monitoring
   tests: True
 
+allow-newer: libsystemd-journal:base
+
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
   tag: 64351aaa3b27fd5a28fc7d1f9c48f9e5a815dab2
   --sha256: 10zw06rnfl39kw43pkv1h1x0lwd768bvs6ddn9y92vs9yafw1hlz
   subdir: Win32-network
-
-source-repository-package
-  type: git
-  location: https://github.com/CodiePP/libsystemd-journal.git
-  tag: 49ad111e668e0d6e06e759a13d8de311bc91e149
-  --sha256: 060ag4hhq64ya8a8xdgv2m0hs9559sxfka63cl9kydka74hvzab0
 
 constraints:
   ip < 1.5,


### PR DESCRIPTION
description
-----------
See https://github.com/haskell/cabal/issues/7083 for an explanation of why `source-repository-package` stanzas that reference packages on a specific platform causes problems for platforms where the package doesn't build.

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
