### PR TITLE
Severity monoid

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -39,12 +39,12 @@ module Cardano.BM.Configuration
     , CM.testSubTrace
     ) where
 
+import           Data.Foldable (fold)
 import           Data.Text (Text)
 import           Data.Maybe (fromMaybe)
 
 import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.LogItem
-import           Cardano.BM.Data.Severity (Severity (..))
 
 \end{code}
 %endif
@@ -66,7 +66,7 @@ testSeverity :: CM.Configuration -> LoggerName -> LOMeta -> IO Bool
 testSeverity config loggername meta = do
     globminsev  <- CM.minSeverity config
     globnamesev <- CM.inspectSeverity config loggername
-    let minsev = max globminsev $ fromMaybe Debug globnamesev
+    let minsev = globminsev <> fold globnamesev
     return $ (severity meta) >= minsev
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs
@@ -54,6 +54,31 @@ data Severity = Debug
               | Emergency
                 deriving (Show, Eq, Ord, Bounded, Enum, Generic, ToJSON, Read)
 
+\end{code}
+
+|Severity| is a \href{https://www.wikiwand.com/en/Semilattice}{lower
+semilattice}, and thus a monoid:
+\begin{code}
+instance Semigroup Severity where
+  Debug     <> _         = Debug
+  _         <> Debug     = Debug
+  Info      <> _         = Info
+  _         <> Info      = Info
+  Notice    <> _         = Notice
+  _         <> Notice    = Notice
+  Warning   <> _         = Warning
+  _         <> Warning   = Warning
+  Error     <> _         = Error
+  _         <> Error     = Error
+  Critical  <> _         = Critical
+  _         <> Critical  = Critical
+  Alert     <> _         = Alert
+  _         <> Alert     = Alert
+  Emergency <> Emergency = Emergency
+
+instance Monoid Severity where
+  mempty = Emergency
+
 instance FromJSON Severity where
     parseJSON = withText "severity" $ \case
                     "Debug"     -> pure Debug


### PR DESCRIPTION
This patch introduces a commutative monoid instance for Severity which
should be used for any severity calucations.  Unfortuntately it is not
possible to remove `Ord` instance, which can be confused.  This patch
also fixes `testSeverity` computation.  It should compare the message
severity with minimum severity found in any configuration settings.
This allows to turn on messages from a tracer  for better dubugging
information, rather than turn them off.  That seems like a more
sensible default.
