### PR TITLE
hydra:  mark tests as required

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -39,12 +39,12 @@ module Cardano.BM.Configuration
     , CM.testSubTrace
     ) where
 
-import           Data.Foldable (fold)
 import           Data.Text (Text)
 import           Data.Maybe (fromMaybe)
 
 import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Severity (Severity (..))
 
 \end{code}
 %endif
@@ -66,7 +66,7 @@ testSeverity :: CM.Configuration -> LoggerName -> LOMeta -> IO Bool
 testSeverity config loggername meta = do
     globminsev  <- CM.minSeverity config
     globnamesev <- CM.inspectSeverity config loggername
-    let minsev = globminsev <> fold globnamesev
+    let minsev = globminsev `max` fromMaybe Debug globnamesev
     return $ (severity meta) >= minsev
 
 \end{code}

--- a/release.nix
+++ b/release.nix
@@ -59,7 +59,7 @@ let
     native = mapTestOn (__trace (__toJSON (packagePlatforms project)) (packagePlatforms project));
     # "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross project);
   } // (mkRequiredJob (
-      collectComponents jobs.native.tests ++
+      collectComponents jobs.native.checks ++
       collectComponents jobs.native.benchmarks ++
       collectComponents jobs.native.libs ++
       collectComponents jobs.native.exes


### PR DESCRIPTION
This restores the test being part of required checks for Hydra.

The regression happened because the `haskell.nix` attribute denoting tests was renamed from `tests` to `checks`.