### PR TITLE
severities:  restore semantics of #593 and update tests accordingly

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration.lhs
@@ -39,12 +39,12 @@ module Cardano.BM.Configuration
     , CM.testSubTrace
     ) where
 
+import           Data.Foldable (fold)
 import           Data.Text (Text)
 import           Data.Maybe (fromMaybe)
 
 import qualified Cardano.BM.Configuration.Model as CM
 import           Cardano.BM.Data.LogItem
-import           Cardano.BM.Data.Severity (Severity (..))
 
 \end{code}
 %endif
@@ -66,7 +66,7 @@ testSeverity :: CM.Configuration -> LoggerName -> LOMeta -> IO Bool
 testSeverity config loggername meta = do
     globminsev  <- CM.minSeverity config
     globnamesev <- CM.inspectSeverity config loggername
-    let minsev = globminsev `max` fromMaybe Debug globnamesev
+    let minsev = globminsev <> fold globnamesev
     return $ (severity meta) >= minsev
 
 \end{code}

--- a/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
@@ -58,7 +58,7 @@ defaultConfigStdout = do
 defaultConfigTesting :: IO CM.Configuration
 defaultConfigTesting = do
     c <- CM.empty
-    CM.setMinSeverity c Debug
+    CM.setMinSeverity c Warning
     CM.setSetupBackends c [KatipBK, AggregationBK]
     CM.setDefaultBackends c [KatipBK, AggregationBK]
     CM.setSetupScribes c [ ScribeDefinition {

--- a/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
+++ b/iohk-monitoring/test/Cardano/BM/Test/Trace.lhs
@@ -410,16 +410,16 @@ unitNamedMinSeverity = do
     let trace = appendName "sev-change" basetrace
     logInfo trace "Message #1"
 
-    -- raise the minimum severity to Warning
-    setSeverity cfg "test-named-severity.sev-change" (Just Warning)
+    -- lower the minimum severity of a particular trace to Warning
+    setSeverity cfg "test-named-severity.sev-change" (Just Info)
     msev <- Cardano.BM.Configuration.inspectSeverity cfg "test-named-severity.sev-change"
     assertBool ("min severity should be Warning, but is " ++ (show msev))
-               (msev == Just Warning)
+               (msev == Just Info)
     -- this message will not be traced
     logInfo trace "Message #2"
 
-    -- lower the minimum severity to Info
-    setSeverity cfg "test-named-severity.sev-change" (Just Info)
+    -- raise the minimum severity to Error
+    setSeverity cfg "test-named-severity.sev-change" (Just Error)
     -- this message is traced
     logInfo trace "Message #3"
 
@@ -430,13 +430,6 @@ unitNamedMinSeverity = do
     assertBool
         ("Found more or less messages than expected: " ++ show res)
         (length res == 2)
-    assertBool
-        ("Found Info message when Warning was minimum severity: " ++ show res)
-        (all
-            (\case
-                LogObject _ (LOMeta _ _ _ Info _) (LogMessage "Message #2") -> False
-                _ -> True)
-            res)
 
 \end{code}
 


### PR DESCRIPTION
Previously, before #593, to determine whether a message passes
the severity threshold, the 'testSeverity' predicate was
computing a maximum of global and per-trace severities.

Therefore, originally, there was no way to enable a particular tracer,
although it was possible to mute one.

So, #593 fixed that, by making `testSeverity` compare messages
against the _minimum_ of global and per-trace severities.

That PR was temporarily reverted due to failing tests and
my confusion.

Thanks to @coot for digging into the details here!
