### PR TITLE
CAD-2167: TraceForwarderBK plugin with callback.

### DIFF
--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -511,7 +511,7 @@ main = do
       >>= loadPlugin sb
     forwardTo <- CM.getForwardTo c
     when (isJust forwardTo) $
-      Cardano.BM.Backend.TraceForwarder.plugin c tr sb "forwarderMinSeverity"
+      Cardano.BM.Backend.TraceForwarder.plugin c tr sb "forwarderMinSeverity" (return [])
         >>= loadPlugin sb
     Cardano.BM.Backend.Aggregation.plugin c tr sb
       >>= loadPlugin sb


### PR DESCRIPTION
description
-----------

- [x] Now TraceForwarderBK provides a callback that will return a list of `LogObject`s that should be sent directly (not from the message queue).


checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
