### PR TITLE
Externalize EKG Server to make direct EKG access possible

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -109,6 +109,7 @@ library
                        contravariant,
                        directory,
                        filepath,
+                       ekg,
                        katip,
                        mtl,
                        network,

--- a/iohk-monitoring/src/Cardano/BM/Plugin.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Plugin.lhs
@@ -11,9 +11,11 @@ module Cardano.BM.Plugin
   )
   where
 
+import           System.Remote.Monitoring (Server)
+
 import           Cardano.BM.Backend.Log (Scribe)
 import           Cardano.BM.Backend.Switchboard (Switchboard,
-                     addExternalBackend, addExternalScribe)
+                     addExternalBackend, addExternalScribe, setSbEKGServer)
 import           Cardano.BM.Data.Backend
 import           Cardano.BM.Data.BackendKind ()
 import           Cardano.BM.Data.Output
@@ -27,6 +29,7 @@ A |Plugin| has a name and is either a |Backend| or a |Scribe|.
 
 data Plugin a = BackendPlugin !(Backend a) BackendKind
               | ScribePlugin Scribe ScribeId
+              | EKGPlugin !(Backend a) BackendKind (Maybe Server)
 \end{code}
 
 \subsubsection{Plugin behaviour}
@@ -38,5 +41,8 @@ loadPlugin sb (BackendPlugin be bk) = do
     addExternalBackend sb be bk
 loadPlugin sb (ScribePlugin sc nm) = do
   addExternalScribe sb sc nm
+loadPlugin sb (EKGPlugin be bk condSv) = do
+    setSbEKGServer condSv sb
+    addExternalBackend sb be bk
 
 \end{code}

--- a/plugins/backend-ekg/src/Cardano/BM/Backend/EKGView.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/EKGView.lhs
@@ -68,9 +68,11 @@ plugin :: (IsEffectuator s a, ToJSON a, FromJSON a)
        => Configuration -> Trace.Trace IO a -> s a -> IO (Plugin a)
 plugin config trace sb = do
     be :: Cardano.BM.Backend.EKGView.EKGView a <- realizefrom config trace sb
-    return $ BackendPlugin
+    ekgInt <- readMVar (getEV be)
+    return $ EKGPlugin
                (MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be })
                (bekind be)
+               (evServer ekgInt)
 \end{code}
 
 \subsubsection{Structure of EKGView}\label{code:EKGView}\index{EKGView}


### PR DESCRIPTION
Used for CAD-2572 in Node (Direct submission for chainDB metrics to EKG)
-----------
-  The one instance of EKG Server is made accessible via the Switchboard

checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
