### PR TITLE
Filter any invalid characters from generated Prometheus metrics names

### DIFF
--- a/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
@@ -105,7 +105,7 @@ spawnPrometheus ekg host port prometheusOutput = Async.async $
         <> charUtf8 ' '
         <> bld
         <> charUtf8 '\n'
-    prepareName nm = encodeUtf8 $ T.replace " " "_" $ T.replace "-" "_" $ T.replace "." "_" $ T.replace "," "" nm
+    prepareName nm = encodeUtf8 $ T.filter (flip elem (['a'..'z']++['A'..'Z']++['_'])) $ T.replace " " "_" $ T.replace "-" "_" $ T.replace "." "_" nm
     isFloat v = case double v of
         Right (_n, "") -> True  -- only floating point number parsed, no leftover
         _ -> False

--- a/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
+++ b/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs
@@ -105,7 +105,7 @@ spawnPrometheus ekg host port prometheusOutput = Async.async $
         <> charUtf8 ' '
         <> bld
         <> charUtf8 '\n'
-    prepareName nm = encodeUtf8 $ T.replace " " "_" $ T.replace "-" "_" $ T.replace "." "_" nm
+    prepareName nm = encodeUtf8 $ T.replace " " "_" $ T.replace "-" "_" $ T.replace "." "_" $ T.replace "," "" nm
     isFloat v = case double v of
         Right (_n, "") -> True  -- only floating point number parsed, no leftover
         _ -> False


### PR DESCRIPTION
description
-----------

On Cardano Node 1.25.1, hitting the Prometheus metrics endpoints has output such as the following:
```
.
.
.
cardano_node_metrics_RTS_gcLiveBytes_int 1073611024
cardano_node_metrics_txsProcessedNum_int 74
rts_gc_init_cpu_ms 2
cardano_node_ChainDB_before_next_messages_elided_int 821668172805
cardano_node_ChainDB_block_replay_progress_(%)_real 99.9
cardano_node_metrics_RTS_gcMinorNum_int 825
rts_gc_bytes_allocated 24341461824
cardano_node_metrics_epoch_int 250
rts_gc_num_bytes_usage_samples 18
rts_gc_current_bytes_slop 5975792
cardano_node_metrics_RTS_mutticks_int 1822
.
.
.
```

The lines containing `cardano_node_ChainDB_before_next,_messages_elided_int` and `cardano_node_ChainDB_block_replay_progress_(%)_real` caused parse errors in Prometheus due to "unsupported character in float", because of the comma and percentage symbol.

I traced this to [this line](https://github.com/input-output-hk/iohk-monitoring-framework/blob/f0f804f1b64c1f58b071e3eb69d6b56549ed09fa/plugins/backend-ekg/src/Cardano/BM/Backend/Prometheus.lhs#L108), where spaces and hyphens are replaced with `'_'` in the generated metrics names.

- [x] describe solution here ..

I fixed this by filtering any characters that are not alphabetic, or an underscore, from the generated names. The generated names then look like this:
```
.
.
.
cardano_node_metrics_txsProcessedNum_int 411
rts_gc_init_cpu_ms 2
cardano_node_ChainDB_before_next_messages_elided_int 1256041765991
cardano_node_ChainDB_block_replay_progress__real 100.0
cardano_node_metrics_RTS_gcMinorNum_int 1207
rts_gc_bytes_allocated 36005984256
cardano_node_metrics_epoch_int 250
.
.
.
```

Which are able to be parsed by prometheus.

In investigating this, I first made [this issue](https://github.com/input-output-hk/cardano-node/issues/2407) in the Cardano Node repository, but realized it orginated here.

Happy to update this if you'd like to see any other changes!

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
