### PR TITLE
Move implicit `Representation` transformation into `FromJSON` instance

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Configuration.lhs
@@ -27,7 +27,7 @@ module Cardano.BM.Data.Configuration
   where
 
 import           Control.Exception (throwIO)
-import           Data.Aeson.Types (typeMismatch)
+import           Data.Aeson.Types (genericParseJSON, defaultOptions, typeMismatch)
 import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.HashMap.Strict as HM
@@ -107,7 +107,10 @@ data Representation = Representation
     , traceAcceptAt   :: Maybe [RemoteAddrNamed]
     , options         :: HM.HashMap Text Value
     }
-    deriving (Generic, Show, ToJSON, FromJSON)
+    deriving (Eq, Generic, Show, ToJSON)
+
+instance FromJSON Representation where
+  parseJSON value = implicit_fill_representation <$> genericParseJSON defaultOptions value
 
 data RemoteAddr
   = RemotePipe FilePath
@@ -125,15 +128,15 @@ data RemoteAddrNamed = RemoteAddrNamed
 \begin{code}
 readRepresentation :: FilePath -> IO Representation
 readRepresentation fp =
-    either throwIO pure =<< parseRepresentation <$> BS.readFile fp
+    either throwIO pure =<< decodeEither' <$> BS.readFile fp
 
 \end{code}
 
 \subsubsection{parseRepresentation}\label{code:parseRepresentation}\index{parseRepresentation}
 \begin{code}
+{-# DEPRECATED parseRepresentation "Use decodeEither' instead" #-}
 parseRepresentation :: ByteString -> Either ParseException Representation
-parseRepresentation =
-    fmap implicit_fill_representation . decodeEither'
+parseRepresentation = decodeEither'
 
 \end{code}
 


### PR DESCRIPTION
Description
-----------

Moves the implicit `Representation` transformation into the `FromJSON` instance. Doing this makes sure that the implicit transformation is also done when Representation is parsed with `fromJSON`. Specifically, this allows properly getting a Representation from a non-toplevel configuration field like:

```
logging:
  minVerbosity: Info
  hasEKG: 12788
```

In addition, this commit:
- Derives the missing Eq instance for Representation
- Deprecates `parseRepresentation`, as `decodeEither'` can now be used
  directly instead

Checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
