### PR TITLE
Upgrade to cabal-3.4.0.0

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2.0.0'
+        cabal-version: '3.4.0.0'
 
     - name: Patch GHC 8.10.2 linker
       if: matrix.os == 'windows-latest' && matrix.ghc == '8.10.2'
@@ -54,7 +54,7 @@ jobs:
       run: retry 3 cabal update
 
     - name: Cabal Configure
-      run: retry 3 cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
+      run: retry 3 cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
     - uses: actions/cache@v2
       name: Cache cabal store
@@ -64,10 +64,10 @@ jobs:
         restore-keys: cache-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles('cabal-cache.cabal') }}-
 
     - name: Install dependencies
-      run: retry 3 cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies
+      run: retry 3 cabal build all --only-dependencies
 
     - name: Build
-      run: retry 3 cabal build all --builddir="$CABAL_BUILDDIR"
+      run: retry 3 cabal build all
 
     - name: Run tests
-      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" cabal test --builddir="$CABAL_BUILDDIR" all
+      run: TMPDIR="${{ runner.temp }}" TMP="${{ runner.temp }}" cabal test all

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-10-01T00:00:00Z
+index-state: 2021-03-15T00:00:00Z
 
 packages:
   contra-tracer

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5fc93a3fd171bb40b97585e5eb2cab43dc467446",
-        "sha256": "0a4q51jsxsy6z1ljbfr97haffzhwsrai74mzj17ljk8d78c26kfm",
+        "rev": "e7961eee7bbaaa195b3255258f40d5536574eb74",
+        "sha256": "0ils54jldagmgn3c1s7994s9gwv5mz5l9lpsn7c9islhhmx2wlzb",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/5fc93a3fd171bb40b97585e5eb2cab43dc467446.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/e7961eee7bbaaa195b3255258f40d5536574eb74.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "07e5844fdf6fe99f41229d7392ce81cfe191bcfc",
-        "sha256": "0p2z6jidm4rlp2yjfl553q234swj1vxl8z0z8ra1hm61lfrlcmb9",
+        "rev": "fe9aef0135d6496e2b2121c37217a57af78d4e69",
+        "sha256": "0k4n5hmjrcxa2nfdlvkx16s001khda4h22ng27bxc11rn9rf3d33",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/07e5844fdf6fe99f41229d7392ce81cfe191bcfc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fe9aef0135d6496e2b2121c37217a57af78d4e69.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-   }
+    }
 }


### PR DESCRIPTION
Remove `--builddir` work around which is not needed for `ghc-8.10.x` onwards.
Update index state to `2021-03-15`.