### PR TITLE
Add ToObject requirement and tests

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -1,5 +1,5 @@
 name:                 iohk-monitoring
-version:              0.1.10.1
+version:              0.2.0.0
 synopsis:             logging, benchmarking and monitoring framework
 -- description:
 license:              Apache-2.0

--- a/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs
@@ -58,7 +58,7 @@ import           Cardano.BM.Data.LogItem
 import           Cardano.BM.Data.Severity
 import           Cardano.BM.Data.SubTrace (SubTrace (..))
 import           Cardano.BM.Data.Trace (Trace)
-import           Cardano.BM.Data.Tracer (Tracer (..))
+import           Cardano.BM.Data.Tracer (Tracer (..), ToObject(..))
 import qualified Cardano.BM.Backend.Log
 import qualified Cardano.BM.Backend.LogBuffer
 
@@ -165,14 +165,14 @@ instance IsEffectuator Switchboard a where
 
 |Switchboard| is an |IsBackend|
 \begin{code}
-instance (FromJSON a, ToJSON a) => IsBackend Switchboard a where
+instance (FromJSON a, ToJSON a, ToObject a) => IsBackend Switchboard a where
     bekind _ = SwitchboardBK
 
     realize cfg = realizeSwitchboard cfg
     unrealize switchboard = unrealizeSwitchboard switchboard
 
 
-realizeSwitchboard :: (FromJSON a, ToJSON a) => Configuration -> IO (Switchboard a)
+realizeSwitchboard :: (FromJSON a, ToJSON a, ToObject a) => Configuration -> IO (Switchboard a)
 realizeSwitchboard cfg = do
     -- we setup |LogBuffer| explicitly so we can access it as a |Backend| and as |LogBuffer|
     logbuf :: Cardano.BM.Backend.LogBuffer.LogBuffer a <- Cardano.BM.Backend.LogBuffer.realize cfg


### PR DESCRIPTION
This changes the output of `ScText`-configured loggers to use the
'ToObject' typeclass to get the text representation. In particular, we
now use the 'textTransformer' function to get the output, which by
default comes from the ToJSON instance, but can be customised as one may
wish (in particular, for example, to be the output of a pretty-printer).

This is related to https://jira.iohk.io/browse/SCP-2229.

Open questions:

- Is this the best way to do this?
- This is a breaking change for lots of users; should there be some advice along these lines?

Note that because of the breaking change, I followed PVP and upgraded it to version 0.2. 

checklist
---------

- [x] compiles (`cabal v2-build` or `stack build`)
- [x] tests run successfully (`cabal v2-test` or `stack test`)
- [x] documentation added
- [x] link to an issue
- [ ] add milestone (the current sprint)
