### PR TITLE
CDA-490 backend to Kafka

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,13 +46,14 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install libsystemd0 libsystemd-dev librdkafka-dev
+        #sudo apt-get -y install libsystemd0 libsystemd-dev librdkafka-dev
+        sudo apt-get -y install libsystemd0 libsystemd-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
 
-    - name: Install build environment (Mac OSX)
-      if: matrix.os == 'macos-latest'
-      run: HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install librdkafka
+    #- name: Install build environment (Mac OSX)
+    #  if: matrix.os == 'macos-latest'
+    #  run: HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install librdkafka
 
     - name: Cabal update
       run: retry 3 cabal update

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,13 +42,17 @@ jobs:
           's|C:/GitLabRunner/builds/2WeHDSFP/0/ghc/ghc/inplace/mingw/bin/ld.exe|C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/mingw/bin/ld.exe|g' \
           C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/lib/settings
 
-    - name: Install build environment
+    - name: Install build environment (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get -y install libsystemd0 libsystemd-dev
+        sudo apt-get -y install libsystemd0 libsystemd-dev librdkafka-dev
         sudo apt-get -y remove --purge software-properties-common
         sudo apt-get -y autoremove
+
+    - name: Install build environment (Mac OSX)
+      if: matrix.os == 'macos-latest'
+      run: HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install librdkafka
 
     - name: Cabal update
       run: retry 3 cabal update

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,7 @@ packages:
   plugins/backend-editor
   plugins/backend-ekg
   plugins/backend-graylog
+  plugins/backend-kafka
   plugins/backend-monitoring
   plugins/backend-trace-acceptor
   plugins/backend-trace-forwarder

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,7 @@ packages:
   plugins/backend-editor
   plugins/backend-ekg
   plugins/backend-graylog
-  plugins/backend-kafka
+  --plugins/backend-kafka
   plugins/backend-monitoring
   plugins/backend-trace-acceptor
   plugins/backend-trace-forwarder

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -20,7 +20,8 @@
 #define RUN_ProcCounterOutput
 
 -- if defined loads the Kafka plugin and outputs metrics to topic 'test'
-#define OUT_KafkaStream
+-- also needs changes to cabal and nix files, stack.yaml
+#undef OUT_KafkaStream
 
 module Main
   ( main )

--- a/examples/complex/Main.lhs
+++ b/examples/complex/Main.lhs
@@ -19,6 +19,9 @@
 #define RUN_ProcBufferDump
 #define RUN_ProcCounterOutput
 
+-- if defined loads the Kafka plugin and outputs metrics to topic 'test'
+#define OUT_KafkaStream
+
 module Main
   ( main )
   where
@@ -47,6 +50,9 @@ import           System.Random
 import           Cardano.BM.Backend.Aggregation
 import           Cardano.BM.Backend.Editor
 import           Cardano.BM.Backend.EKGView
+#if defined(OUT_KafkaStream)
+import           Cardano.BM.Backend.Kafka
+#endif
 import           Cardano.BM.Backend.Monitoring
 import           Cardano.BM.Backend.Switchboard (Switchboard, readLogBuffer)
 import           Cardano.BM.Backend.TraceForwarder
@@ -258,6 +264,9 @@ prepare_configuration = do
     CM.setBackends c "complex.#aggregation.complex.monitoring" (Just [MonitoringBK])
     CM.setBackends c "complex.#aggregation.complex.observeIO" (Just [EKGViewBK])
 
+#if defined(OUT_KafkaStream)
+    CM.setBackends c "complex.counters" (Just [KatipBK, UserDefinedBK "KafkaStream" ])
+#endif
     CM.setScribes c "complex.counters" (Just ["StdoutSK::stdout","FileSK::logs/out.json"])
 
     CM.setEKGBindAddr c $ Just (Endpoint ("localhost", 12790))
@@ -276,6 +285,10 @@ output could also be forwarded using a pipe:
     CM.setTextOption c "forwarderMinSeverity" "Warning"  -- sets min severity filter in forwarder
     CM.setTextOption c "prometheusOutput" "json"  -- Prometheus' output in JSON-format
 
+#if defined(OUT_KafkaStream)
+    CM.setTextOption c "kafka_servers" "192.168.11.42:9092,localhost:9092"  -- Kafka servers to try
+    CM.setTextOption c "kafka_topic" "test"  -- output to Kafka topic 'test'
+#endif
     CM.setForwardDelay c (Just 1000)
 
     CM.setMonitors c $ HM.fromList
@@ -517,6 +530,10 @@ main = do
       >>= loadPlugin sb
     Cardano.BM.Backend.Monitoring.plugin c tr sb
       >>= loadPlugin sb
+#if defined(OUT_KafkaStream)
+    Cardano.BM.Backend.Kafka.plugin c tr sb
+      >>= loadPlugin sb
+#endif
 #ifdef LINUX
     -- inspect logs with 'journalctl -t example-complex'
     Cardano.BM.Scribe.Systemd.plugin c tr sb "example-complex"

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -87,7 +87,7 @@ executable example-complex
                        lobemo-backend-aggregation,
                        lobemo-backend-editor,
                        lobemo-backend-ekg,
-                       lobemo-backend-kafka,
+                       --lobemo-backend-kafka,
                        lobemo-backend-monitoring,
                        lobemo-backend-trace-forwarder,
                        lobemo-scribe-systemd,

--- a/examples/lobemo-examples.cabal
+++ b/examples/lobemo-examples.cabal
@@ -87,6 +87,7 @@ executable example-complex
                        lobemo-backend-aggregation,
                        lobemo-backend-editor,
                        lobemo-backend-ekg,
+                       lobemo-backend-kafka,
                        lobemo-backend-monitoring,
                        lobemo-backend-trace-forwarder,
                        lobemo-scribe-systemd,

--- a/plugins/backend-kafka/LICENSE
+++ b/plugins/backend-kafka/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/backend-kafka/NOTICE
+++ b/plugins/backend-kafka/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2021 IOHK
+
+Licensed under the Apache License, Version 2.0 (the "License”). You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/plugins/backend-kafka/README.md
+++ b/plugins/backend-kafka/README.md
@@ -1,0 +1,20 @@
+# Kafka backend
+
+This backend can be loaded as a plugin and then log items can be directed to a Kafka topic.
+
+## Configuration options
+
+ * "kafka_servers" - this is a string of a server name or IP address with port number separated by a ':'. Multiple servers can be indicated with separated names by ','.
+ * "kafka_topic" - the name of the topic to which log items shall be sent to. Currently, only a single topic is supported.
+ (place these key-value pairs in the configuration section "options")
+
+## Example
+
+the [example-complex](examples/complex/Main.lhs) is extended with sending out metrics to a Kafka topic.
+
+
+## References
+
+- using Haskell bindings to librdkafka: https://hackage.haskell.org/package/hw-kafka-client
+
+- learn more about [Kafka](https://kafka.apache.org/)

--- a/plugins/backend-kafka/Setup.hs
+++ b/plugins/backend-kafka/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/plugins/backend-kafka/lobemo-backend-kafka.cabal
+++ b/plugins/backend-kafka/lobemo-backend-kafka.cabal
@@ -1,0 +1,28 @@
+cabal-version:       2.0
+name:                lobemo-backend-kafka
+version:             0.1.0.0
+synopsis:            provides a backend implementation to Kafka
+homepage:            https://github.com/input-output-hk/iohk-monitoring-framework
+license:             Apache-2.0
+license-files:       LICENSE, NOTICE
+author:              Alexander Diemand
+maintainer:          operations@iohk.io
+copyright:           2021 IOHK
+category:            Benchmarking
+build-type:          Simple
+extra-source-files:  README.md
+
+library
+  exposed-modules:     Cardano.BM.Backend.Kafka
+  default-extensions:  OverloadedStrings
+  build-depends:       base >=4.11,
+                       iohk-monitoring,
+                       aeson,
+                       async,
+                       bytestring,
+                       hw-kafka-client,
+                       safe-exceptions,
+                       stm,
+                       text
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/plugins/backend-kafka/src/Cardano/BM/Backend/Kafka.lhs
+++ b/plugins/backend-kafka/src/Cardano/BM/Backend/Kafka.lhs
@@ -1,0 +1,192 @@
+
+\subsection{Cardano.BM.Backend.Kafka}
+\label{code:Cardano.BM.Backend.Kafka}
+
+%if style == newcode
+\begin{code}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+
+module Cardano.BM.Backend.Kafka
+    (
+      KafkaStream
+    -- * Plugin
+    , plugin
+    ) where
+
+import           Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
+import           Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar,
+                     readMVar, withMVar, tryTakeMVar)
+import           Control.Concurrent.STM (atomically, retry)
+import qualified Control.Concurrent.STM.TBQueue as TBQ
+import           Control.Exception.Safe (throwM)
+import           Control.Monad (void, when)
+import           Data.Aeson (FromJSON, ToJSON (..), Value, encode, (.=))
+import qualified Data.ByteString.Lazy.Char8 as BS8
+import           Data.Maybe (catMaybes)
+import           Data.Text (Text, split)
+import qualified Data.Text.IO as TIO
+import qualified Kafka.Producer as K
+import           System.IO (stderr)
+
+import           Cardano.BM.Configuration (Configuration, getTextOption, getTextOptionOrDefault)
+import           Cardano.BM.Data.Backend
+import           Cardano.BM.Data.LogItem
+import           Cardano.BM.Data.Severity
+import           Cardano.BM.Plugin
+import qualified Cardano.BM.Trace as Trace
+
+\end{code}
+%endif
+
+\subsubsection{Plugin definition}
+\begin{code}
+plugin :: (IsEffectuator s a, ToJSON a, FromJSON a)
+       => Configuration -> Trace.Trace IO a -> s a -> IO (Plugin a)
+plugin config trace sb = do
+    be :: Cardano.BM.Backend.Kafka.KafkaStream a <- realizefrom config trace sb
+    return $ BackendPlugin
+               (MkBackend { bEffectuate = effectuate be, bUnrealize = unrealize be })
+               (bekind be)
+\end{code}
+
+\subsubsection{Structure of KafkaStream}\label{code:KafkaStream}\index{KafkaStream}
+\begin{code}
+type KafkaMVar a = MVar (KafkaInternal a)
+newtype KafkaStream a = KafkaStream
+    { getK :: KafkaMVar a }
+
+data KafkaInternal a = KafkaInternal
+    { kQueue    :: TBQ.TBQueue (Maybe (LogObject a))
+    , kDispatch :: Async.Async ()
+    }
+
+\end{code}
+
+\subsubsection{KafkaStream is an effectuator}\index{KafkaStream!instance of IsEffectuator}
+Function |effectuate| is called to pass in a |LogObject| to forward to Kafka.
+In case the queue is full, all new items are dropped.
+\begin{code}
+instance IsEffectuator KafkaStream a where
+    effectuate kstream item = do
+        kref <- readMVar (getK kstream)
+        nocapacity <- atomically $ TBQ.isFullTBQueue (kQueue kref)
+        if nocapacity
+        then handleOverflow kstream
+        else atomically $ TBQ.writeTBQueue (kQueue kref) (Just item)
+
+    handleOverflow _ = TIO.hPutStrLn stderr "Notice: Kafkas's queue full, dropping log items!"
+
+\end{code}
+
+\subsubsection{|KafkaStream| implements |Backend| functions}\index{KafkaStream!instance of IsBackend}
+
+|KafkaStream| is an |IsBackend|
+\begin{code}
+instance (ToJSON a, FromJSON a) => IsBackend KafkaStream a where
+    bekind _ = UserDefinedBK "KafkaStream"
+
+    realize _ = fail "KafkaStream cannot be instantiated by 'realize'"
+
+    realizefrom config sbtrace _ = do
+        kref <- newEmptyMVar
+        let kstream = KafkaStream kref
+        let qSize = 8192
+        queue <- atomically $ TBQ.newTBQueue qSize
+        dispatcher <- spawnDispatcher config queue sbtrace
+        -- link the given Async to the current thread, such that if the Async
+        -- raises an exception, that exception will be re-thrown in the current
+        -- thread, wrapped in ExceptionInLinkedThread.
+        Async.link dispatcher
+        putMVar kref $ KafkaInternal
+                        { kQueue = queue
+                        , kDispatch = dispatcher
+                        }
+        return kstream
+
+    unrealize kstream = do
+        let clearMVar :: MVar b -> IO ()
+            clearMVar = void . tryTakeMVar
+
+        (dispatcher, queue) <- withMVar (getK kstream) (\kref ->
+                                return (kDispatch kref, kQueue kref))
+        -- send terminating item to the queue
+        atomically $ TBQ.writeTBQueue queue Nothing
+        -- exit the dispatcher
+        res <- Async.waitCatch dispatcher
+        either throwM return res
+        clearMVar $ getK kstream
+
+\end{code}
+
+\subsubsection{Asynchronously reading log items from the queue and their processing}
+\begin{code}
+spawnDispatcher :: forall a. ToJSON a
+                => Configuration
+                -> TBQ.TBQueue (Maybe (LogObject a))
+                -> Trace.Trace IO a
+                -> IO (Async.Async ())
+spawnDispatcher config evqueue sbtrace =
+    Async.async (initState >>= qProc)
+  where
+    ktrace = Trace.appendName "#Kafka" sbtrace
+
+    initState :: IO (Trace.Trace IO a, Maybe K.KafkaProducer)
+    initState = do
+        kproducer <- createProducer
+        return (ktrace, kproducer)
+
+    createProducer = do
+        kprops <- getKprops config
+        kp <- K.newProducer kprops
+        return $ case kp of
+                    Left _ -> Nothing
+                    Right p -> Just p
+
+    getKprops :: Configuration -> IO K.ProducerProperties
+    getKprops config = do
+        kservers0 <- getTextOption config "kafka_servers"
+        let kservers = case kservers0 of
+                        Nothing -> [K.BrokerAddress "localhost:9092"]
+                        Just s -> map K.BrokerAddress $ split (==',') s
+        return (K.brokersList kservers <> K.logLevel K.KafkaLogDebug)
+
+    {-@ lazy qProc @-}
+    qProc :: (Trace.Trace IO a, Maybe K.KafkaProducer) -> IO ()
+    qProc (tr, Nothing) = do
+        threadDelay 2500000
+        initState >>= qProc
+    qProc state@(tr, Just kproducer) = do
+        qitems <- atomically $ do
+                    list <- TBQ.flushTBQueue evqueue
+                    when (null list) retry   -- blocks until new items av.
+                    return list
+        let l1 = length qitems
+        let los = catMaybes qitems
+        let l2 = length los
+        when (l2 > 0) $ do
+            topic <- getTextOptionOrDefault config "kafka_topic" "unknown_topic"
+            res <- K.produceMessageBatch kproducer $ map (encodeMessage (K.TopicName topic)) los
+            when (length res > 0) $ do
+                    mle <- mkLOMeta Error Public
+                    Trace.traceNamedObject tr (mle, LogError "some messages failed to deliver to topic")
+                    threadDelay 500000
+        if (l1 > l2)
+        then K.closeProducer kproducer
+        else qProc state
+
+    encodeMessage :: ToJSON a => K.TopicName ->LogObject a -> K.ProducerRecord
+    encodeMessage topic lo =
+        let m = BS8.toStrict $ encode lo
+        in K.ProducerRecord
+                    { K.prTopic = topic
+                    , K.prPartition = K.UnassignedPartition
+                    , K.prKey = Nothing
+                    , K.prValue = Just m
+                    }
+
+\end{code}

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ let
       lobemo-backend-editor
       lobemo-backend-ekg
       lobemo-backend-graylog
+      lobemo-backend-kafka
       lobemo-backend-monitoring
       lobemo-backend-trace-acceptor
       lobemo-backend-trace-forwarder

--- a/shell.nix
+++ b/shell.nix
@@ -22,7 +22,7 @@ let
       lobemo-backend-editor
       lobemo-backend-ekg
       lobemo-backend-graylog
-      lobemo-backend-kafka
+      #lobemo-backend-kafka
       lobemo-backend-monitoring
       lobemo-backend-trace-acceptor
       lobemo-backend-trace-forwarder

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ packages:
   - plugins/backend-editor
   - plugins/backend-ekg
   - plugins/backend-graylog
-  - plugins/backend-kafka
+  #- plugins/backend-kafka
   - plugins/backend-monitoring
   - plugins/backend-trace-acceptor
   - plugins/backend-trace-forwarder
@@ -49,7 +49,7 @@ nix:
             , openssl.dev, openssl.out
             , libsodium.dev, libsodium.out
             , haskell.compiler.ghc8104
-            , rdkafka
+            #, rdkafka
             , pkg-config
             , systemd.dev
             ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
   # GHC 8.6.5
-resolver: lts-14.27
-compiler: ghc-8.6.5
+#resolver: lts-14.27
+#compiler: ghc-8.6.5
 
-  # GHC 8.10.2
-#resolver: nightly-2020-08-26
-#compiler: ghc-8.10.2
+  # GHC 8.10.4
+resolver: lts-17.13
+compiler: ghc-8.10.4
 
 packages:
   - contra-tracer
@@ -14,6 +14,7 @@ packages:
   - plugins/backend-editor
   - plugins/backend-ekg
   - plugins/backend-graylog
+  - plugins/backend-kafka
   - plugins/backend-monitoring
   - plugins/backend-trace-acceptor
   - plugins/backend-trace-forwarder
@@ -23,19 +24,18 @@ packages:
 allow-newer: false
 
 extra-deps:
-  # needed for GHC 8.10.2
-  #- async-timer-0.2.0.0
+  # needed for GHC 8.10.4
+  - async-timer-0.2.0.0
+  - unliftio-core-0.1.2.0
+
   - network-3.1.1.1
-  - snap-core-1.0.4.1
-  - snap-server-1.1.1.1
+  - snap-server-1.1.2.0
 
-  - time-units-1.0.0
-  - katip-0.8.4.0
+  #- time-units-1.0.0
+  #- katip-0.8.4.0
 
-  - git: https://github.com/input-output-hk/ouroboros-network
-    commit: a09f209bb6bbb1a1a9a5b31d671da0189001e175
-    subdirs:
-        - Win32-network
+  - git: https://github.com/input-output-hk/Win32-network
+    commit: 94153b676617f8f33abe8d8182c37377d2784bd1
 
   - git: https://github.com/CodiePP/libsystemd-journal
     commit: 49ad111e668e0d6e06e759a13d8de311bc91e149
@@ -48,7 +48,8 @@ nix:
   packages: [ zlib.dev, zlib.out
             , openssl.dev, openssl.out
             , libsodium.dev, libsodium.out
-            , haskell.compiler.ghc8102
+            , haskell.compiler.ghc8104
+            , rdkafka
             , pkg-config
             , systemd.dev
             ]


### PR DESCRIPTION
a backend plugin towards [Kafka](https://kafka.apache.org/)

the last commit restores status quo and makes the plugin invisible, so it does not introduce a new dependency.
if one wants to use it, some changes to cabal and nix files are required. 