### PR TITLE
Update to latest GHC 8.10 version

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,6 +35,13 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.4.0.0'
 
+    - name: Patch GHC 8.10.7 linker
+      if: matrix.os == 'windows-latest' && matrix.ghc == '8.10.7'
+      run: |
+         sed -i \
+           's|C:/GitLabRunner/builds/2WeHDSFP/0/ghc/ghc/inplace/mingw/bin/ld.exe|C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/mingw/bin/ld.exe|g' \
+           C:/ProgramData/chocolatey/lib/ghc.8.10.7/tools/ghc-8.10.7/lib/settings
+
     - name: Install build environment
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.2"]
+        ghc: ["8.10.7"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -34,13 +34,6 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.4.0.0'
-
-    - name: Patch GHC 8.10.2 linker
-      if: matrix.os == 'windows-latest' && matrix.ghc == '8.10.2'
-      run: |
-        sed -i \
-          's|C:/GitLabRunner/builds/2WeHDSFP/0/ghc/ghc/inplace/mingw/bin/ld.exe|C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/mingw/bin/ld.exe|g' \
-          C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/lib/settings
 
     - name: Install build environment
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -29,7 +29,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: retry 3 choco install -y pkgconfiglite
 
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Update to latest GHC 8.10 version there doesn't seem to be a reason why this is on an older version than both `cardano-node` and `cardano-db-sync`.