### PR TITLE
Bump versions for upload to CHaP

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -1,5 +1,5 @@
 name:                 iohk-monitoring
-version:              0.1.11.2
+version:              0.1.11.3
 synopsis:             logging, benchmarking and monitoring framework
 -- description:
 license:              Apache-2.0

--- a/tracer-transformers/tracer-transformers.cabal
+++ b/tracer-transformers/tracer-transformers.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                tracer-transformers
-version:             0.1.0.3
+version:             0.1.0.4
 synopsis:            tracer transformers and examples showing their use
 -- description:
 -- bug-reports:


### PR DESCRIPTION
`contra-tracer` does not need to be bumped.