### PR TITLE
Add `defaultConfigStderr` for tracing to stderr

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Configuration/Static.lhs
@@ -53,6 +53,38 @@ defaultConfigStdout = do
 
 \end{code}
 
+\subsubsection{Default configuration outputting on |stderr|}
+\begin{code}
+defaultConfigStderr :: IO CM.Configuration
+defaultConfigStderr = do
+    c <- CM.empty
+    CM.setMinSeverity c Debug
+    CM.setSetupBackends c [KatipBK]
+    CM.setDefaultBackends c [KatipBK]
+    CM.setSetupScribes c [ ScribeDefinition {
+                              scName = "text"
+                            , scFormat = ScText
+                            , scKind = StderrSK
+                            , scPrivacy = ScPublic
+                            , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
+                            }
+                         ,  ScribeDefinition {
+                              scName = "json"
+                            , scFormat = ScJson
+                            , scKind = StderrSK
+                            , scPrivacy = ScPublic
+                            , scRotation = Nothing
+                            , scMinSev = minBound
+                            , scMaxSev = maxBound
+                            }
+                         ]
+    CM.setDefaultScribes c ["StderrSK::text"]
+    return c
+
+\end{code}
+
 \subsubsection{Default configuration for testing}
 \begin{code}
 defaultConfigTesting :: IO CM.Configuration


### PR DESCRIPTION


(Haven't been able to figure out why running `nix-shell` doesn't work, get this error:

```
building '/nix/store/bb729yclf297zin94f7fmsmww2a391f3-git-ls-files.drv'...
error:
       … in the left operand of the update (//) operator

         at /home/user/src/iohk-monitoring-framework/shell.nix:66:8:

           65|
           66|  shell // { inherit devops; }
             |        ^
           67|

       … in the left operand of the update (//) operator

         at /nix/store/pchwfifqmjbq5bwmlbli5l9w3h299hx5-haskell.nix-src/overlays/haskell.nix:780:25:

          779|         cabalProject = args: let p = cabalProject' args;
          780|             in p.hsPkgs // p;
             |                         ^
          781|

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Index state found was  and no `index-sha256` was provided.
```
)

checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
