### PR TITLE
TracingVerbosity: add Show and FromJSON instances

### DIFF
--- a/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
+++ b/iohk-monitoring/src/Cardano/BM/Data/Tracer.lhs
@@ -59,7 +59,7 @@ module Cardano.BM.Data.Tracer
 import           Control.Monad (when)
 import           Control.Monad.IO.Class (MonadIO (..))
 
-import           Data.Aeson (Object, ToJSON (..), Value (..))
+import           Data.Aeson (Object, ToJSON (..), Value (..), FromJSON(..))
 import           Data.Aeson.Text (encodeToLazyText)
 import qualified Data.HashMap.Strict as HM
 import           Data.Text (Text)
@@ -190,8 +190,17 @@ The tracing verbosity will be passed to instances of |ToObject| for rendering
 the traced item accordingly.
 \begin{code}
 data TracingVerbosity = MinimalVerbosity | NormalVerbosity | MaximalVerbosity
-                        deriving (Eq, Read, Ord)
+                        deriving (Eq, Read, Ord, Show)
 
+instance FromJSON TracingVerbosity where
+  parseJSON (String str) = case str of
+    "MinimalVerbosity" -> pure MinimalVerbosity
+    "MaximalVerbosity" -> pure MaximalVerbosity
+    "NormalVerbosity" -> pure NormalVerbosity
+    err -> fail $ "Parsing of TracingVerbosity failed, "
+                <> T.unpack err <> " is not a valid TracingVerbosity"
+  parseJSON invalid  = fail $ "Parsing of TracingVerbosity failed due to type mismatch. "
+                           <> "Encountered: " <> show invalid
 \end{code}
 
 \subsubsection{ToObject - transforms a logged item to a JSON Object}


### PR DESCRIPTION
Contributes to fixing https://github.com/input-output-hk/cardano-node/issues/5470

description
-----------

In the cardano-cli team, we are in the process of removing some orphan instances. This is a PR to get of these [two orphan instances](https://github.com/input-output-hk/cardano-node/blob/396739ca42a3b09fc5e3df698f34cec391f795aa/cardano-node/src/Cardano/Node/Orphans.hs#L22) of `TracingVerbosity`.

checklist
---------

- [X] compiles (`cabal v2-build` or `stack build`)
- [X] tests run successfully (`cabal v2-test` or `stack test`). Kind of: this PR doesn't change the current state: before and after this PR, `cabal test all` yields: `1 out of 69 tests failed (4.23s)` (`Use -p '/demonstrate capturing of counters/' to rerun this test only`)
- NA documentation added
- NA - link to an issue - this is a maintenance operation
- NA - add milestone (the current sprint) - this is a maintenance operation
