### PR TITLE
Add Prometheus labels for Cardano build info display

### DIFF
--- a/plugins/backend-ekg/lobemo-backend-ekg.cabal
+++ b/plugins/backend-ekg/lobemo-backend-ekg.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                lobemo-backend-ekg
-version:             0.1.0.3
+version:             0.1.1.0
 synopsis:            provides a backend implementation to EKG
 -- description:
 homepage:            https://github.com/input-output-hk/iohk-monitoring-framework


### PR DESCRIPTION
This pull request enhances the Cardano build info display by adding support for Prometheus labels. By incorporating Prometheus labels into the build info metrics, we improve monitoring and observability capabilities for Cardano nodes.

This is a restricted solution, which allows metrics with labels only with a value of 1.