### PR TITLE
Bring in readFile fixes from new tracing

### DIFF
--- a/iohk-monitoring/iohk-monitoring.cabal
+++ b/iohk-monitoring/iohk-monitoring.cabal
@@ -1,5 +1,5 @@
 name:                 iohk-monitoring
-version:              0.2.1.0
+version:              0.2.1.1
 synopsis:             logging, benchmarking and monitoring framework
 -- description:
 license:              Apache-2.0


### PR DESCRIPTION
description
-----------

Bring in the readFile fixes from new tracing subsystem.

The plain lazy readFile could cause cardano-node to leak file descriptors until it crashed.


checklist
---------

- [ ] compiles (`cabal v2-build` or `stack build`)
- [ ] tests run successfully (`cabal v2-test` or `stack test`)
- [ ] documentation added
- [ ] link to an issue
- [ ] add milestone (the current sprint)
